### PR TITLE
Search less restrictively for clubhouse tickets in branch names

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ import {
 } from "./types";
 
 export const CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-export const CLUBHOUSE_BRANCH_NAME_REGEXP = /[A-Za-z-]+\/ch(\d+)\/[A-Za-z-]/;
+export const CLUBHOUSE_BRANCH_NAME_REGEXP = /.+ch(\d+).+/;
 
 interface Stringable {
   toString(): string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ import {
 } from "./types";
 
 export const CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-export const CLUBHOUSE_BRANCH_NAME_REGEXP = /.*ch(\d+).*/;
+export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+\/)?ch(\d+)(?:\/.+)?$/;
 
 interface Stringable {
   toString(): string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ import {
 } from "./types";
 
 export const CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-export const CLUBHOUSE_BRANCH_NAME_REGEXP = /.+ch(\d+).+/;
+export const CLUBHOUSE_BRANCH_NAME_REGEXP = /.*ch(\d+).*/;
 
 interface Stringable {
   toString(): string;


### PR DESCRIPTION
Branch naming heuristics for including clubhouse ticket identifiers (ch####) can be made less restrictive with the understanding that it is the first check of two before creating a new clubhouse ticket. This allows for branch names that begin, middle, or end with a clubhouse ticket.

Possible collisions can occur if somebody has not actually make a clubhouse ticket and for some reason names their branch with the letters "ch" followed by at least one number, e.g. they make a PR from a branch names `test_branch5`. `ch5` would be identified as a clubhouse ticket, and it would not trigger the creation of one.

this seems relatively low risk, however I'm down for minimally requires a `/` prior to the clubhouse ticket to imply some nested directories, though i don't think we need one after.