### PR TITLE
Allow hyphens as separators in branch name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ It works for the opposite use-case, assuming that the Clubhouse story exists
 _before_ the pull request is created.
 
 This Action will specifically check for branch names that follow the naming
-convention for this built-in integration. Any branch name that looks like
-`*/ch####/*` will be ignored by this Action, on the assumption that a Clubhouse
-story already exists for the pull request.
+convention for this built-in integration. Any branch name that contains
+`ch####` will be ignored by this Action, on the assumption that a Clubhouse
+story already exists for the pull request. The `ch####` must be separated
+from leading or following text with either a `/` or a `-`. So, branches
+named `ch1`, `prefix/ch23`, `prefix-ch123`, `ch3456/suffix`, `ch3456-suffux`,
+`prefix/ch987/suffix` would match, but `xch123` and `ch987end` would not.
 
 ## Customizing the Pull Request Comment
 

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -94,6 +94,28 @@ test("getClubhouseWorkflowState", async () => {
   scope.done();
 });
 
+test("getClubhouseStoryIdFromBranchName matching", () => {
+  [["ch1", "1"], 
+    ["ch89/something", "89"], 
+    ["ch99-something", "99"],
+    ["prefix-1/ch123", "123"],
+    ["prefix-1-ch321", "321"],
+    ["prefix/ch5678/suffix", "5678"],
+    ["prefix-ch6789/suffix-more", "6789"],
+    ["prefix/ch7890-suffix", "7890"],
+    ["prefix-ch0987-suffix-extra", "0987"]].forEach(item => {
+    const id = util.getClubhouseStoryIdFromBranchName(item[0]);
+    expect(id).toEqual(item[1]);
+  });
+});
+
+test("getClubhouseStoryIdFromBranchName non-matching", () => {
+  ["prefix/ch8765+suffix", "ch554X", "ach8765", "this_ch1234"].forEach(branch => {
+    const id = util.getClubhouseStoryIdFromBranchName(branch);
+    expect(id).toBeNull();
+  })
+});
+
 test("getClubhouseURLFromPullRequest", async () => {
   const payload = {
     pull_request: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -279,7 +279,7 @@ exports.updateClubhouseStoryById = exports.addCommentToPullRequest = exports.get
 const core = __importStar(__webpack_require__(186));
 const github = __importStar(__webpack_require__(438));
 exports.CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-exports.CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+\/)?ch(\d+)(?:\/.+)?$/;
+exports.CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-\/])?ch(\d+)(?:[-\/].+)?$/;
 /**
  * Convert a Map to a sorted string representation. Useful for debugging.
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,7 +13,7 @@ import {
 } from "./types";
 
 export const CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+\/)?ch(\d+)(?:\/.+)?$/;
+export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-\/])?ch(\d+)(?:[-\/].+)?$/;
 
 interface Stringable {
   toString(): string;


### PR DESCRIPTION
The clubhouse documentation indicates the story id needs to be separated from the rest of the branch name by slashes. However, it is actually less restrictive than this. We are using branch names like `ch1234-something-else`

This works fine with the clubhouse integration. I dislike the use of slashes in this instance because many git UI clients use the slash as sort of a namespace or directory. Using `ch1234/something-else` would hide the `something else` in a tree like structure. This is useful for places that include the username at the beginning of the branch names like `user/something-else` because it groups all user branches together. However in this case, there will likely only ever be one branch per story, so I find it annoying.

This change would allow branch names like `user/ch1234/whatever-else`, `user-ch1234-whatever-else`, `ch1234/whatever-else`, `ch1234-whatever-else`, `ch123`, etc - `/` and `-` would be interchangeable as separators.