### PR TITLE
enhancement: add repo name to clubhouse story title

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -453,7 +453,7 @@ function createClubhouseStory(payload, http) {
             return null;
         }
         const body = {
-            name: payload.pull_request.title,
+            name: `${payload.repository.name} - ${payload.pull_request.title}`,
             description: payload.pull_request.body,
             project_id: clubhouseProject.id,
             external_tickets: [

--- a/src/util.ts
+++ b/src/util.ts
@@ -237,7 +237,7 @@ export async function createClubhouseStory(
   }
 
   const body: ClubhouseCreateStoryBody = {
-    name: payload.pull_request.title,
+    name: `${payload.repository.name} - ${payload.pull_request.title}`,
     description: payload.pull_request.body,
     project_id: clubhouseProject.id,
     external_tickets: [


### PR DESCRIPTION
@singingwolfboy, this request to add to the repo name to the Clubhouse story title. We have several microservices and frontend repos we are using your Github Action for and we would great benefit by the name of the repo being added to the Clubhouse story title. I presume we could potentially add this as an input attribute to the GH action, but I would be curious how often users would not want the repo name in their Clubhouse story title (or at least minimally the description).