### PR TITLE
feat: Add ability to customize Clubhouse story title and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ variables, like this:
     merged-state-name: Done
     closed-state-name: Abandoned
     clubhouse-story-title-template: >-
-      {{{ payload.repository.name }}} - {{{ payload.pull_request.title }}} # Would show "<repo name> - <pull request title>"
+      {{{ payload.repository.name }}} - {{{ payload.pull_request.title }}} 
     clubhouse-story-body-template: >-
       New story create for pull request {{{ payload.pull_request.title }}} in repo {{{ payload.repository.name }}}. The body of the PR is {{{ payload.pull_request.body }}}
 ```

--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ variables, like this:
     clubhouse-story-title-template: >-
       {{{ payload.repository.name }}} - {{{ payload.pull_request.title }}} 
     clubhouse-story-body-template: >-
-      :zap: New story created for pull request [**{{{ payload.pull_request.title }}}**]({{{ payload.pull_request.html }}}) in repo **{{{ payload.repository.name }}}**. The body of the PR is: 
-      {{{ payload.pull_request.body }}}
+      :zap: New story created for pull request [**{{{ payload.pull_request.title }}}**]({{{ payload.pull_request.html_url }}}) 
+      in repo **{{{ payload.repository.name }}}**. 
+      {{{ #payload.pull_request.body }}}
+        The body of the PR is: {{{ payload.pull_request.body }}}
+      {{{ /payload.pull_request.body }}}
 ```
 
 The story title and body templates are processed using the [Mustache](https://mustache.github.io/)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ template output valid Markdown, as shown above.
 If you don't provide a comment template, this action will use this comment template
 by default: `Clubhouse story: {{{ story.app_url }}}`
 
+## Customizing the Clubhouse Story Title and Body
+
+You can customize the Clubhouse **title** or **body** when creating stories using the `clubhouse-story-title-template` and `clubhouse-story-body-template`
+variables, like this:
+
+```yaml
+- uses: singingwolfboy/create-linked-clubhouse-story@v1.7
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    clubhouse-token: ${{ secrets.CLUBHOUSE_TOKEN }}
+    project-name: Engineering
+    opened-state-name: Started
+    merged-state-name: Done
+    closed-state-name: Abandoned
+    clubhouse-story-title-template: >-
+      {{{ payload.repository.name }}} - {{{ payload.pull_request.title }}} # Would show "<repo name> - <pull request title>"
+    clubhouse-story-body-template: >-
+      New story create for pull request {{{ payload.pull_request.title }}} in repo {{{ payload.repository.name }}}. The body of the PR is {{{ payload.pull_request.body }}}
+```
+
+This comment template is processed using the [Mustache](https://mustache.github.io/)
+templating system. It receives [the Payload object returned from the GitHub API](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request). Note that you may want to use the
+triple mustache syntax to disable HTML escaping.
+
+If you don't provide a title template or body template, this action will use Pull Request Title and Pull Request Body by default. `{{{ payload.pull_request.title }}}` `{{{ payload.pull_request.body }}}`
+
 ## User Map
 
 This Action does its best to automatically assign the created Clubhouse story

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ variables, like this:
     clubhouse-story-title-template: >-
       {{{ payload.repository.name }}} - {{{ payload.pull_request.title }}} 
     clubhouse-story-body-template: >-
-      New story create for pull request {{{ payload.pull_request.title }}} in repo {{{ payload.repository.name }}}. The body of the PR is {{{ payload.pull_request.body }}}
+      :zap: New story created for pull request [**{{{ payload.pull_request.title }}}**]({{{ payload.pull_request.html }}}) in repo **{{{ payload.repository.name }}}**. The body of the PR is: 
+      {{{ payload.pull_request.body }}}
 ```
 
-This comment template is processed using the [Mustache](https://mustache.github.io/)
-templating system. It receives [the Payload object returned from the GitHub API](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request). Note that you may want to use the
-triple mustache syntax to disable HTML escaping.
+The story title and body templates are processed using the [Mustache](https://mustache.github.io/)
+templating system. It receives [the Payload object returned from the GitHub API](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request). Note that you may want to use the triple mustache syntax to disable HTML escaping. Also Clubhouse supports full Markdown formatting, emojis, and @ mentions. Feel free to use them to your heart's desire. :heart_eyes_cat:
 
-If you don't provide a title template or body template, this action will use Pull Request Title and Pull Request Body by default. `{{{ payload.pull_request.title }}}` `{{{ payload.pull_request.body }}}`
+If you don't provide a title or body template, this action will simply use the Pull Request Title (`{{{ payload.pull_request.title }}}`) and Pull Request Body (`{{{ payload.pull_request.body }}}`) by default.  
 
 ## User Map
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ by default: `Clubhouse story: {{{ story.app_url }}}`
 
 ## Customizing the Clubhouse Story Title and Body
 
-You can customize the Clubhouse **title** or **body** when creating stories using the `clubhouse-story-title-template` and `clubhouse-story-body-template`
+You can customize the Clubhouse **title** and **description** when creating stories using the `story-title-template` and `story-description-template`
 variables, like this:
 
 ```yaml
-- uses: singingwolfboy/create-linked-clubhouse-story@v1.7
+- uses: singingwolfboy/create-linked-clubhouse-story@v1.5
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     clubhouse-token: ${{ secrets.CLUBHOUSE_TOKEN }}
@@ -97,9 +97,9 @@ variables, like this:
     opened-state-name: Started
     merged-state-name: Done
     closed-state-name: Abandoned
-    clubhouse-story-title-template: >-
+    story-title-template: >-
       {{{ payload.repository.name }}} - {{{ payload.pull_request.title }}} 
-    clubhouse-story-body-template: >-
+    story-description-template: >-
       :zap: New story created for pull request [**{{{ payload.pull_request.title }}}**]({{{ payload.pull_request.html_url }}}) 
       in repo **{{{ payload.repository.name }}}**. 
       {{{ #payload.pull_request.body }}}

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,16 @@ inputs:
       Clubhouse story is successfully created. The template is populated
       with a `story` variable.
     default: "Clubhouse story: {{{ story.app_url }}}"
+  clubhouse-story-title-template:
+    description: >-
+      A Mustache template used for the story title in Clubhouse. The template is populated with a
+      `payload` variable.
+    default: "{{{ payload.pull_request.title }}}"
+  clubhouse-story-body-template:
+    description: >-
+      A Mustache template used for the story body in Clubhouse. The template is populated with a
+      `payload` variable.
+    default: "{{{ payload.pull_request.body }}}"
   only-users:
     description: Comma-separated list of specific GitHub users to create Clubhouse stories for. 
   ignored-users:

--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,14 @@ inputs:
       Clubhouse story is successfully created. The template is populated
       with a `story` variable.
     default: "Clubhouse story: {{{ story.app_url }}}"
-  clubhouse-story-title-template:
+  story-title-template:
     description: >-
       A Mustache template used for the story title in Clubhouse. The template is populated with a
       `payload` variable.
     default: "{{{ payload.pull_request.title }}}"
-  clubhouse-story-body-template:
+  story-description-template:
     description: >-
-      A Mustache template used for the story body in Clubhouse. The template is populated with a
+      A Mustache template used for the story description in Clubhouse. The template is populated with a
       `payload` variable.
     default: "{{{ payload.pull_request.body }}}"
   only-users:

--- a/dist/index.js
+++ b/dist/index.js
@@ -223,7 +223,13 @@ function opened() {
             return;
         }
         const http = new http_client_1.HttpClient();
-        const story = yield util_1.createClubhouseStory(payload, http);
+        const CLUBHOUSE_STORY_TITLE_TEMPLATE = core.getInput("clubhouse-story-title-template");
+        const storyTitle = mustache_1.default.render(CLUBHOUSE_STORY_TITLE_TEMPLATE, {
+            payload,
+        });
+        const CLUBHOUSE_STORY_BODY_TEMPLATE = core.getInput("clubhouse-story-body-template");
+        const storyBody = mustache_1.default.render(CLUBHOUSE_STORY_BODY_TEMPLATE, { payload });
+        const story = yield util_1.createClubhouseStory(payload, http, storyTitle, storyBody);
         if (!story) {
             return;
         }
@@ -471,7 +477,7 @@ function getClubhouseWorkflowState(stateName, http, project) {
     });
 }
 exports.getClubhouseWorkflowState = getClubhouseWorkflowState;
-function createClubhouseStory(payload, http) {
+function createClubhouseStory(payload, http, storyTitle, storyBody) {
     return __awaiter(this, void 0, void 0, function* () {
         const CLUBHOUSE_TOKEN = core.getInput("clubhouse-token", {
             required: true,
@@ -488,8 +494,8 @@ function createClubhouseStory(payload, http) {
             return null;
         }
         const body = {
-            name: payload.pull_request.title,
-            description: payload.pull_request.body,
+            name: storyTitle,
+            description: storyBody,
             project_id: clubhouseProject.id,
             external_tickets: [
                 {

--- a/dist/index.js
+++ b/dist/index.js
@@ -223,13 +223,7 @@ function opened() {
             return;
         }
         const http = new http_client_1.HttpClient();
-        const CLUBHOUSE_STORY_TITLE_TEMPLATE = core.getInput("clubhouse-story-title-template");
-        const storyTitle = mustache_1.default.render(CLUBHOUSE_STORY_TITLE_TEMPLATE, {
-            payload,
-        });
-        const CLUBHOUSE_STORY_BODY_TEMPLATE = core.getInput("clubhouse-story-body-template");
-        const storyBody = mustache_1.default.render(CLUBHOUSE_STORY_BODY_TEMPLATE, { payload });
-        const story = yield util_1.createClubhouseStory(payload, http, storyTitle, storyBody);
+        const story = yield util_1.createClubhouseStory(payload, http);
         if (!story) {
             return;
         }
@@ -277,12 +271,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.updateClubhouseStoryById = exports.addCommentToPullRequest = exports.getClubhouseURLFromPullRequest = exports.getClubhouseStoryIdFromBranchName = exports.createClubhouseStory = exports.getClubhouseWorkflowState = exports.getClubhouseProjectByName = exports.getClubhouseProject = exports.getClubhouseStoryById = exports.getClubhouseUserId = exports.getUserListAsSet = exports.shouldProcessPullRequestForUser = exports.CLUBHOUSE_BRANCH_NAME_REGEXP = exports.CLUBHOUSE_STORY_URL_REGEXP = void 0;
 const core = __importStar(__webpack_require__(186));
 const github = __importStar(__webpack_require__(438));
+const mustache_1 = __importDefault(__webpack_require__(272));
 exports.CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-exports.CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-\/])?ch(\d+)(?:[-\/].+)?$/;
+exports.CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?ch(\d+)(?:[-/].+)?$/;
 /**
  * Convert a Map to a sorted string representation. Useful for debugging.
  *
@@ -477,15 +475,15 @@ function getClubhouseWorkflowState(stateName, http, project) {
     });
 }
 exports.getClubhouseWorkflowState = getClubhouseWorkflowState;
-function createClubhouseStory(payload, http, storyTitle, storyBody) {
+function createClubhouseStory(payload, http) {
     return __awaiter(this, void 0, void 0, function* () {
-        const CLUBHOUSE_TOKEN = core.getInput("clubhouse-token", {
-            required: true,
-        });
-        const PROJECT_NAME = core.getInput("project-name", {
-            required: true,
-        });
+        const CLUBHOUSE_TOKEN = core.getInput("clubhouse-token", { required: true });
+        const PROJECT_NAME = core.getInput("project-name", { required: true });
         const STATE_NAME = core.getInput("opened-state-name");
+        const TITLE_TEMPLATE = core.getInput("story-title-template");
+        const title = mustache_1.default.render(TITLE_TEMPLATE, { payload });
+        const DESCRIPTION_TEMPLATE = core.getInput("story-description-template");
+        const description = mustache_1.default.render(DESCRIPTION_TEMPLATE, { payload });
         const githubUsername = payload.pull_request.user.login;
         const clubhouseUserId = yield getClubhouseUserId(githubUsername, http);
         const clubhouseProject = yield getClubhouseProjectByName(PROJECT_NAME, http);
@@ -494,8 +492,8 @@ function createClubhouseStory(payload, http, storyTitle, storyBody) {
             return null;
         }
         const body = {
-            name: storyTitle,
-            description: storyBody,
+            name: title,
+            description,
             project_id: clubhouseProject.id,
             external_tickets: [
                 {

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -33,24 +33,7 @@ export default async function opened(): Promise<void> {
 
   const http = new HttpClient();
 
-  const CLUBHOUSE_STORY_TITLE_TEMPLATE = core.getInput(
-    "clubhouse-story-title-template"
-  );
-  const storyTitle = Mustache.render(CLUBHOUSE_STORY_TITLE_TEMPLATE, {
-    payload,
-  });
-
-  const CLUBHOUSE_STORY_BODY_TEMPLATE = core.getInput(
-    "clubhouse-story-body-template"
-  );
-  const storyBody = Mustache.render(CLUBHOUSE_STORY_BODY_TEMPLATE, { payload });
-
-  const story = await createClubhouseStory(
-    payload,
-    http,
-    storyTitle,
-    storyBody
-  );
+  const story = await createClubhouseStory(payload, http);
   if (!story) {
     return;
   }

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -32,7 +32,14 @@ export default async function opened(): Promise<void> {
   }
 
   const http = new HttpClient();
-  const story = await createClubhouseStory(payload, http);
+
+  const CLUBHOUSE_STORY_TITLE_TEMPLATE = core.getInput("clubhouse-story-title-template");
+  const storyTitle = Mustache.render(CLUBHOUSE_STORY_TITLE_TEMPLATE, { payload });
+
+  const CLUBHOUSE_STORY_BODY_TEMPLATE = core.getInput("clubhouse-story-body-template");
+  const storyBody = Mustache.render(CLUBHOUSE_STORY_BODY_TEMPLATE, { payload });
+
+  const story = await createClubhouseStory(payload, http, storyTitle, storyBody);
   if (!story) {
     return;
   }

--- a/src/opened.ts
+++ b/src/opened.ts
@@ -33,13 +33,24 @@ export default async function opened(): Promise<void> {
 
   const http = new HttpClient();
 
-  const CLUBHOUSE_STORY_TITLE_TEMPLATE = core.getInput("clubhouse-story-title-template");
-  const storyTitle = Mustache.render(CLUBHOUSE_STORY_TITLE_TEMPLATE, { payload });
+  const CLUBHOUSE_STORY_TITLE_TEMPLATE = core.getInput(
+    "clubhouse-story-title-template"
+  );
+  const storyTitle = Mustache.render(CLUBHOUSE_STORY_TITLE_TEMPLATE, {
+    payload,
+  });
 
-  const CLUBHOUSE_STORY_BODY_TEMPLATE = core.getInput("clubhouse-story-body-template");
+  const CLUBHOUSE_STORY_BODY_TEMPLATE = core.getInput(
+    "clubhouse-story-body-template"
+  );
   const storyBody = Mustache.render(CLUBHOUSE_STORY_BODY_TEMPLATE, { payload });
 
-  const story = await createClubhouseStory(payload, http, storyTitle, storyBody);
+  const story = await createClubhouseStory(
+    payload,
+    http,
+    storyTitle,
+    storyBody
+  );
   if (!story) {
     return;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -270,7 +270,9 @@ export async function getClubhouseWorkflowState(
 
 export async function createClubhouseStory(
   payload: EventPayloads.WebhookPayloadPullRequest,
-  http: HttpClient
+  http: HttpClient,
+  storyTitle: string,
+  storyBody: string
 ): Promise<ClubhouseStory | null> {
   const CLUBHOUSE_TOKEN = core.getInput("clubhouse-token", {
     required: true,
@@ -289,8 +291,8 @@ export async function createClubhouseStory(
   }
 
   const body: ClubhouseCreateStoryBody = {
-    name: payload.pull_request.title,
-    description: payload.pull_request.body,
+    name: storyTitle,
+    description: storyBody,
     project_id: clubhouseProject.id,
     external_tickets: [
       {


### PR DESCRIPTION
@singingwolfboy, this PR has a feature that includes the ability for users of this GitHub Action to customize the title and body of the created Clubhouse story using the same custom comment template you're using for the PR comments. If neither `clubhouse-story-title-template` nor `clubhouse-story-body-template` is populated, it simple defaults to the `payload.pull_request.title` and `payload.pull_request.body` as requested.