### PR TITLE
Add support for assigning new stories to an Iteration

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -299,7 +299,9 @@ export async function createClubhouseStory(
   const githubLabels = (payload.pull_request.labels || []).map(
     (label) => label.name
   );
+  core.debug(`githubLabels: ${githubLabels}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
+  core.debug(`clubhouseIterationInfo: ${clubhouseIterationInfo}`);
   const body: ClubhouseCreateStoryBody = {
     name: title,
     description,
@@ -319,6 +321,7 @@ export async function createClubhouseStory(
       clubhouseIterationInfo,
       http
     );
+    core.debug(`clubhouseIteration: ${clubhouseIteration}`);
     if (clubhouseIteration) {
       body.iteration_id = clubhouseIteration.id;
     }


### PR DESCRIPTION
Teams use iterations to track work done over a period of time. It would be nice if this integration could automatically assign created tickets to the relevant Iteration. Otherwise, engineers forget to add work where the PR was created before the ticket.

I have tried to make this fairly generic, but it still requires making some assumptions about how teams and iterations are organized for an organization in Clubhouse.

Also, I have no idea how to test this code, don't know typescript, and have not written tests though I can see the outline of them. Please consider this a draft PR that could use some feedback / pointers in the right direction.