### PR TITLE
Rework Iteration support to use the 'labeled' event trigger

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -492,9 +492,10 @@ function createClubhouseStory(payload, http) {
             return null;
         }
         const githubLabels = (payload.pull_request.labels || []).map((label) => label.name);
-        core.debug(`githubLabels: ${githubLabels}`);
+        core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
+        core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
         const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
-        core.debug(`clubhouseIterationInfo: ${clubhouseIterationInfo}`);
+        core.debug(`clubhouseIterationInfo: ${JSON.stringify(clubhouseIterationInfo)}`);
         const body = {
             name: title,
             description,
@@ -511,7 +512,7 @@ function createClubhouseStory(payload, http) {
         }
         if (clubhouseIterationInfo) {
             const clubhouseIteration = yield getLatestMatchingClubhouseIteration(clubhouseIterationInfo, http);
-            core.debug(`clubhouseIteration: ${clubhouseIteration}`);
+            core.debug(`clubhouseIteration: ${JSON.stringify(clubhouseIteration)}`);
             if (clubhouseIteration) {
                 body.iteration_id = clubhouseIteration.id;
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -492,7 +492,9 @@ function createClubhouseStory(payload, http) {
             return null;
         }
         const githubLabels = (payload.pull_request.labels || []).map((label) => label.name);
+        core.debug(`githubLabels: ${githubLabels}`);
         const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
+        core.debug(`clubhouseIterationInfo: ${clubhouseIterationInfo}`);
         const body = {
             name: title,
             description,
@@ -509,6 +511,7 @@ function createClubhouseStory(payload, http) {
         }
         if (clubhouseIterationInfo) {
             const clubhouseIteration = yield getLatestMatchingClubhouseIteration(clubhouseIterationInfo, http);
+            core.debug(`clubhouseIteration: ${clubhouseIteration}`);
             if (clubhouseIteration) {
                 body.iteration_id = clubhouseIteration.id;
             }
@@ -1296,6 +1299,7 @@ exports.getOctokitOptions = getOctokitOptions;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+const url = __webpack_require__(835);
 const http = __webpack_require__(605);
 const https = __webpack_require__(211);
 const pm = __webpack_require__(443);
@@ -1344,7 +1348,7 @@ var MediaTypes;
  * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
  */
 function getProxyUrl(serverUrl) {
-    let proxyUrl = pm.getProxyUrl(new URL(serverUrl));
+    let proxyUrl = pm.getProxyUrl(url.parse(serverUrl));
     return proxyUrl ? proxyUrl.href : '';
 }
 exports.getProxyUrl = getProxyUrl;
@@ -1363,15 +1367,6 @@ const HttpResponseRetryCodes = [
 const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
-class HttpClientError extends Error {
-    constructor(message, statusCode) {
-        super(message);
-        this.name = 'HttpClientError';
-        this.statusCode = statusCode;
-        Object.setPrototypeOf(this, HttpClientError.prototype);
-    }
-}
-exports.HttpClientError = HttpClientError;
 class HttpClientResponse {
     constructor(message) {
         this.message = message;
@@ -1390,7 +1385,7 @@ class HttpClientResponse {
 }
 exports.HttpClientResponse = HttpClientResponse;
 function isHttps(requestUrl) {
-    let parsedUrl = new URL(requestUrl);
+    let parsedUrl = url.parse(requestUrl);
     return parsedUrl.protocol === 'https:';
 }
 exports.isHttps = isHttps;
@@ -1495,7 +1490,7 @@ class HttpClient {
         if (this._disposed) {
             throw new Error('Client has already been disposed.');
         }
-        let parsedUrl = new URL(requestUrl);
+        let parsedUrl = url.parse(requestUrl);
         let info = this._prepareRequest(verb, parsedUrl, headers);
         // Only perform retries on reads since writes may not be idempotent.
         let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
@@ -1534,7 +1529,7 @@ class HttpClient {
                     // if there's no location to redirect to, we won't
                     break;
                 }
-                let parsedRedirectUrl = new URL(redirectUrl);
+                let parsedRedirectUrl = url.parse(redirectUrl);
                 if (parsedUrl.protocol == 'https:' &&
                     parsedUrl.protocol != parsedRedirectUrl.protocol &&
                     !this._allowRedirectDowngrade) {
@@ -1650,7 +1645,7 @@ class HttpClient {
      * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
      */
     getAgent(serverUrl) {
-        let parsedUrl = new URL(serverUrl);
+        let parsedUrl = url.parse(serverUrl);
         return this._getAgent(parsedUrl);
     }
     _prepareRequest(method, requestUrl, headers) {
@@ -1723,7 +1718,7 @@ class HttpClient {
                 maxSockets: maxSockets,
                 keepAlive: this._keepAlive,
                 proxy: {
-                    proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`,
+                    proxyAuth: proxyUrl.auth,
                     host: proxyUrl.hostname,
                     port: proxyUrl.port
                 }
@@ -1818,8 +1813,12 @@ class HttpClient {
                 else {
                     msg = 'Failed request: (' + statusCode + ')';
                 }
-                let err = new HttpClientError(msg, statusCode);
-                err.result = response.result;
+                let err = new Error(msg);
+                // attach statusCode and body obj (if available) to the error object
+                err['statusCode'] = statusCode;
+                if (response.result) {
+                    err['result'] = response.result;
+                }
                 reject(err);
             }
             else {
@@ -1834,11 +1833,12 @@ exports.HttpClient = HttpClient;
 /***/ }),
 
 /***/ 443:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+const url = __webpack_require__(835);
 function getProxyUrl(reqUrl) {
     let usingSsl = reqUrl.protocol === 'https:';
     let proxyUrl;
@@ -1853,7 +1853,7 @@ function getProxyUrl(reqUrl) {
         proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
     }
     if (proxyVar) {
-        proxyUrl = new URL(proxyVar);
+        proxyUrl = url.parse(proxyVar);
     }
     return proxyUrl;
 }
@@ -1969,43 +1969,56 @@ var request = __webpack_require__(234);
 var graphql = __webpack_require__(668);
 var authToken = __webpack_require__(334);
 
-function _objectWithoutPropertiesLoose(source, excluded) {
-  if (source == null) return {};
-  var target = {};
-  var sourceKeys = Object.keys(source);
-  var key, i;
-
-  for (i = 0; i < sourceKeys.length; i++) {
-    key = sourceKeys[i];
-    if (excluded.indexOf(key) >= 0) continue;
-    target[key] = source[key];
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
   }
 
-  return target;
+  return obj;
 }
 
-function _objectWithoutProperties(source, excluded) {
-  if (source == null) return {};
-
-  var target = _objectWithoutPropertiesLoose(source, excluded);
-
-  var key, i;
+function ownKeys(object, enumerableOnly) {
+  var keys = Object.keys(object);
 
   if (Object.getOwnPropertySymbols) {
-    var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+    var symbols = Object.getOwnPropertySymbols(object);
+    if (enumerableOnly) symbols = symbols.filter(function (sym) {
+      return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+    });
+    keys.push.apply(keys, symbols);
+  }
 
-    for (i = 0; i < sourceSymbolKeys.length; i++) {
-      key = sourceSymbolKeys[i];
-      if (excluded.indexOf(key) >= 0) continue;
-      if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
-      target[key] = source[key];
+  return keys;
+}
+
+function _objectSpread2(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i] != null ? arguments[i] : {};
+
+    if (i % 2) {
+      ownKeys(Object(source), true).forEach(function (key) {
+        _defineProperty(target, key, source[key]);
+      });
+    } else if (Object.getOwnPropertyDescriptors) {
+      Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+    } else {
+      ownKeys(Object(source)).forEach(function (key) {
+        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+      });
     }
   }
 
   return target;
 }
 
-const VERSION = "3.2.4";
+const VERSION = "3.1.2";
 
 class Octokit {
   constructor(options = {}) {
@@ -2037,7 +2050,9 @@ class Octokit {
     }
 
     this.request = request.request.defaults(requestDefaults);
-    this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
+    this.graphql = graphql.withCustomRequest(this.request).defaults(_objectSpread2(_objectSpread2({}, requestDefaults), {}, {
+      baseUrl: requestDefaults.baseUrl.replace(/\/api\/v3$/, "/api")
+    }));
     this.log = Object.assign({
       debug: () => {},
       info: () => {},
@@ -2045,7 +2060,7 @@ class Octokit {
       error: console.error.bind(console)
     }, options.log);
     this.hook = hook; // (1) If neither `options.authStrategy` nor `options.auth` are set, the `octokit` instance
-    //     is unauthenticated. The `this.auth()` method is a no-op and no request hook is registered.
+    //     is unauthenticated. The `this.auth()` method is a no-op and no request hook is registred.
     // (2) If only `options.auth` is set, use the default token authentication strategy.
     // (3) If `options.authStrategy` is set then use it and pass in `options.auth`. Always pass own request as many strategies accept a custom request instance.
     // TODO: type `options.auth` based on `options.authStrategy`.
@@ -2064,21 +2079,8 @@ class Octokit {
         this.auth = auth;
       }
     } else {
-      const {
-        authStrategy
-      } = options,
-            otherOptions = _objectWithoutProperties(options, ["authStrategy"]);
-
-      const auth = authStrategy(Object.assign({
-        request: this.request,
-        log: this.log,
-        // we pass the current octokit instance as well as its constructor options
-        // to allow for authentication strategies that return a new octokit instance
-        // that shares the same internal state as the current one. The original
-        // requirement for this was the "event-octokit" authentication strategy
-        // of https://github.com/probot/octokit-auth-probot.
-        octokit: this,
-        octokitOptions: otherOptions
+      const auth = options.authStrategy(Object.assign({
+        request: this.request
       }, options.auth)); // @ts-ignore  ¯\_(ツ)_/¯
 
       hook.wrap("request", auth.hook);
@@ -2145,7 +2147,9 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __webpack_require__(287);
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var isPlainObject = _interopDefault(__webpack_require__(38));
 var universalUserAgent = __webpack_require__(429);
 
 function lowercaseKeys(object) {
@@ -2162,7 +2166,7 @@ function lowercaseKeys(object) {
 function mergeDeep(defaults, options) {
   const result = Object.assign({}, defaults);
   Object.keys(options).forEach(key => {
-    if (isPlainObject.isPlainObject(options[key])) {
+    if (isPlainObject(options[key])) {
       if (!(key in defaults)) Object.assign(result, {
         [key]: options[key]
       });else result[key] = mergeDeep(defaults[key], options[key]);
@@ -2173,16 +2177,6 @@ function mergeDeep(defaults, options) {
     }
   });
   return result;
-}
-
-function removeUndefinedProperties(obj) {
-  for (const key in obj) {
-    if (obj[key] === undefined) {
-      delete obj[key];
-    }
-  }
-
-  return obj;
 }
 
 function merge(defaults, route, options) {
@@ -2199,10 +2193,7 @@ function merge(defaults, route, options) {
   } // lowercase header names before merging with defaults to avoid duplicates
 
 
-  options.headers = lowercaseKeys(options.headers); // remove properties with undefined values before merging
-
-  removeUndefinedProperties(options);
-  removeUndefinedProperties(options.headers);
+  options.headers = lowercaseKeys(options.headers);
   const mergedOptions = mergeDeep(defaults || {}, options); // mediaType.previews arrays are merged, instead of overwritten
 
   if (defaults && defaults.mediaType.previews.length) {
@@ -2424,7 +2415,7 @@ function parse(options) {
   // https://fetch.spec.whatwg.org/#methods
   let method = options.method.toUpperCase(); // replace :varname with {varname} to make it RFC 6570 compatible
 
-  let url = (options.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
+  let url = (options.url || "/").replace(/:([a-z]\w+)/g, "{+$1}");
   let headers = Object.assign({}, options.headers);
   let body;
   let parameters = omit(options, ["method", "baseUrl", "url", "headers", "request", "mediaType"]); // extract variable names from URL to calculate remaining variables later
@@ -2438,9 +2429,9 @@ function parse(options) {
 
   const omittedParameters = Object.keys(options).filter(option => urlVariableNames.includes(option)).concat("baseUrl");
   const remainingParameters = omit(parameters, omittedParameters);
-  const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
+  const isBinaryRequset = /application\/octet-stream/i.test(headers.accept);
 
-  if (!isBinaryRequest) {
+  if (!isBinaryRequset) {
     if (options.mediaType.format) {
       // e.g. application/vnd.github.v3+json => application/vnd.github.v3.raw
       headers.accept = headers.accept.split(/,/).map(preview => preview.replace(/application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/, `application/vnd$1$2.${options.mediaType.format}`)).join(",");
@@ -2509,7 +2500,7 @@ function withDefaults(oldDefaults, newDefaults) {
   });
 }
 
-const VERSION = "6.0.10";
+const VERSION = "6.0.5";
 
 const userAgent = `octokit-endpoint.js/${VERSION} ${universalUserAgent.getUserAgent()}`; // DEFAULTS has all properties set that EndpointOptions has, except url.
 // So we use RequestParameters and add method as additional required property.
@@ -2535,6 +2526,50 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
+/***/ 38:
+/***/ ((module) => {
+
+"use strict";
+
+
+/*!
+ * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+function isObject(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
+}
+
+function isPlainObject(o) {
+  var ctor,prot;
+
+  if (isObject(o) === false) return false;
+
+  // If has modified constructor
+  ctor = o.constructor;
+  if (ctor === undefined) return true;
+
+  // If has modified prototype
+  prot = ctor.prototype;
+  if (isObject(prot) === false) return false;
+
+  // If constructor does not have an Object-specific method
+  if (prot.hasOwnProperty('isPrototypeOf') === false) {
+    return false;
+  }
+
+  // Most likely a plain Object
+  return true;
+}
+
+module.exports = isPlainObject;
+
+
+/***/ }),
+
 /***/ 668:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
@@ -2546,7 +2581,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 var request = __webpack_require__(234);
 var universalUserAgent = __webpack_require__(429);
 
-const VERSION = "4.5.8";
+const VERSION = "4.5.4";
 
 class GraphqlError extends Error {
   constructor(request, response) {
@@ -2569,18 +2604,13 @@ class GraphqlError extends Error {
 }
 
 const NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
-const GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
 function graphql(request, query, options) {
-  if (typeof query === "string" && options && "query" in options) {
-    return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
-  }
-
-  const parsedOptions = typeof query === "string" ? Object.assign({
+  options = typeof query === "string" ? options = Object.assign({
     query
-  }, options) : query;
-  const requestOptions = Object.keys(parsedOptions).reduce((result, key) => {
+  }, options) : options = query;
+  const requestOptions = Object.keys(options).reduce((result, key) => {
     if (NON_VARIABLE_OPTIONS.includes(key)) {
-      result[key] = parsedOptions[key];
+      result[key] = options[key];
       return result;
     }
 
@@ -2588,17 +2618,9 @@ function graphql(request, query, options) {
       result.variables = {};
     }
 
-    result.variables[key] = parsedOptions[key];
+    result.variables[key] = options[key];
     return result;
-  }, {}); // workaround for GitHub Enterprise baseUrl set with /api/v3 suffix
-  // https://github.com/octokit/auth-app.js/issues/111#issuecomment-657610451
-
-  const baseUrl = parsedOptions.baseUrl || request.endpoint.DEFAULTS.baseUrl;
-
-  if (GHES_V3_SUFFIX_REGEX.test(baseUrl)) {
-    requestOptions.url = baseUrl.replace(GHES_V3_SUFFIX_REGEX, "/api/graphql");
-  }
-
+  }, {});
   return request(requestOptions).then(response => {
     if (response.data.errors) {
       const headers = {};
@@ -2659,7 +2681,7 @@ exports.withCustomRequest = withCustomRequest;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-const VERSION = "2.6.2";
+const VERSION = "2.3.2";
 
 /**
  * Some “list” response that can be paginated have a different response structure
@@ -2712,23 +2734,26 @@ function iterator(octokit, route, parameters) {
   let url = options.url;
   return {
     [Symbol.asyncIterator]: () => ({
-      async next() {
-        if (!url) return {
-          done: true
-        };
-        const response = await requestMethod({
+      next() {
+        if (!url) {
+          return Promise.resolve({
+            done: true
+          });
+        }
+
+        return requestMethod({
           method,
           url,
           headers
+        }).then(normalizePaginatedListResponse).then(response => {
+          // `response.headers.link` format:
+          // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
+          // sets `url` to undefined if "next" URL is not present or `link` header is not set
+          url = ((response.headers.link || "").match(/<([^>]+)>;\s*rel="next"/) || [])[1];
+          return {
+            value: response
+          };
         });
-        const normalizedResponse = normalizePaginatedListResponse(response); // `response.headers.link` format:
-        // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
-        // sets `url` to undefined if "next" URL is not present or `link` header is not set
-
-        url = ((normalizedResponse.headers.link || "").match(/<([^>]+)>;\s*rel="next"/) || [])[1];
-        return {
-          value: normalizedResponse
-        };
       }
 
     })
@@ -2766,10 +2791,6 @@ function gather(octokit, results, iterator, mapFn) {
   });
 }
 
-const composePaginateRest = Object.assign(paginate, {
-  iterator
-});
-
 /**
  * @param octokit Octokit instance
  * @param options Options passed to Octokit constructor
@@ -2784,7 +2805,6 @@ function paginateRest(octokit) {
 }
 paginateRest.VERSION = VERSION;
 
-exports.composePaginateRest = composePaginateRest;
 exports.paginateRest = paginateRest;
 //# sourceMappingURL=index.js.map
 
@@ -2817,24 +2837,13 @@ const Endpoints = {
     deleteSelfHostedRunnerFromRepo: ["DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}"],
     deleteWorkflowRun: ["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"],
     deleteWorkflowRunLogs: ["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"],
-    disableSelectedRepositoryGithubActionsOrganization: ["DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}"],
-    disableWorkflow: ["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable"],
     downloadArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"],
     downloadJobLogsForWorkflowRun: ["GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"],
     downloadWorkflowRunLogs: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs"],
-    enableSelectedRepositoryGithubActionsOrganization: ["PUT /orgs/{org}/actions/permissions/repositories/{repository_id}"],
-    enableWorkflow: ["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable"],
-    getAllowedActionsOrganization: ["GET /orgs/{org}/actions/permissions/selected-actions"],
-    getAllowedActionsRepository: ["GET /repos/{owner}/{repo}/actions/permissions/selected-actions"],
     getArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"],
-    getGithubActionsPermissionsOrganization: ["GET /orgs/{org}/actions/permissions"],
-    getGithubActionsPermissionsRepository: ["GET /repos/{owner}/{repo}/actions/permissions"],
     getJobForWorkflowRun: ["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"],
     getOrgPublicKey: ["GET /orgs/{org}/actions/secrets/public-key"],
     getOrgSecret: ["GET /orgs/{org}/actions/secrets/{secret_name}"],
-    getRepoPermissions: ["GET /repos/{owner}/{repo}/actions/permissions", {}, {
-      renamed: ["actions", "getGithubActionsPermissionsRepository"]
-    }],
     getRepoPublicKey: ["GET /repos/{owner}/{repo}/actions/secrets/public-key"],
     getRepoSecret: ["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"],
     getSelfHostedRunnerForOrg: ["GET /orgs/{org}/actions/runners/{runner_id}"],
@@ -2851,7 +2860,6 @@ const Endpoints = {
     listRunnerApplicationsForOrg: ["GET /orgs/{org}/actions/runners/downloads"],
     listRunnerApplicationsForRepo: ["GET /repos/{owner}/{repo}/actions/runners/downloads"],
     listSelectedReposForOrgSecret: ["GET /orgs/{org}/actions/secrets/{secret_name}/repositories"],
-    listSelectedRepositoriesEnabledGithubActionsOrganization: ["GET /orgs/{org}/actions/permissions/repositories"],
     listSelfHostedRunnersForOrg: ["GET /orgs/{org}/actions/runners"],
     listSelfHostedRunnersForRepo: ["GET /repos/{owner}/{repo}/actions/runners"],
     listWorkflowRunArtifacts: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"],
@@ -2859,12 +2867,7 @@ const Endpoints = {
     listWorkflowRunsForRepo: ["GET /repos/{owner}/{repo}/actions/runs"],
     reRunWorkflow: ["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"],
     removeSelectedRepoFromOrgSecret: ["DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"],
-    setAllowedActionsOrganization: ["PUT /orgs/{org}/actions/permissions/selected-actions"],
-    setAllowedActionsRepository: ["PUT /repos/{owner}/{repo}/actions/permissions/selected-actions"],
-    setGithubActionsPermissionsOrganization: ["PUT /orgs/{org}/actions/permissions"],
-    setGithubActionsPermissionsRepository: ["PUT /repos/{owner}/{repo}/actions/permissions"],
-    setSelectedReposForOrgSecret: ["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"],
-    setSelectedRepositoriesEnabledGithubActionsOrganization: ["PUT /orgs/{org}/actions/permissions/repositories"]
+    setSelectedReposForOrgSecret: ["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"]
   },
   activity: {
     checkRepoIsStarredByAuthenticatedUser: ["GET /user/starred/{owner}/{repo}"],
@@ -2920,7 +2923,6 @@ const Endpoints = {
     getSubscriptionPlanForAccount: ["GET /marketplace_listing/accounts/{account_id}"],
     getSubscriptionPlanForAccountStubbed: ["GET /marketplace_listing/stubbed/accounts/{account_id}"],
     getUserInstallation: ["GET /users/{username}/installation"],
-    getWebhookConfigForApp: ["GET /app/hook/config"],
     listAccountsForPlan: ["GET /marketplace_listing/plans/{plan_id}/accounts"],
     listAccountsForPlanStubbed: ["GET /marketplace_listing/stubbed/plans/{plan_id}/accounts"],
     listInstallationReposForAuthenticatedUser: ["GET /user/installations/{installation_id}/repositories"],
@@ -2935,8 +2937,7 @@ const Endpoints = {
     resetToken: ["PATCH /applications/{client_id}/token"],
     revokeInstallationAccessToken: ["DELETE /installation/token"],
     suspendInstallation: ["PUT /app/installations/{installation_id}/suspended"],
-    unsuspendInstallation: ["DELETE /app/installations/{installation_id}/suspended"],
-    updateWebhookConfigForApp: ["PATCH /app/hook/config"]
+    unsuspendInstallation: ["DELETE /app/installations/{installation_id}/suspended"]
   },
   billing: {
     getGithubActionsBillingOrg: ["GET /orgs/{org}/settings/billing/actions"],
@@ -2947,28 +2948,65 @@ const Endpoints = {
     getSharedStorageBillingUser: ["GET /users/{username}/settings/billing/shared-storage"]
   },
   checks: {
-    create: ["POST /repos/{owner}/{repo}/check-runs"],
-    createSuite: ["POST /repos/{owner}/{repo}/check-suites"],
-    get: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"],
-    getSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"],
-    listAnnotations: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"],
-    listForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"],
-    listForSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"],
-    listSuitesForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"],
-    rerequestSuite: ["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"],
-    setSuitesPreferences: ["PATCH /repos/{owner}/{repo}/check-suites/preferences"],
-    update: ["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]
-  },
-  codeScanning: {
-    getAlert: ["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}", {}, {
-      renamedParameters: {
-        alert_id: "alert_number"
+    create: ["POST /repos/{owner}/{repo}/check-runs", {
+      mediaType: {
+        previews: ["antiope"]
       }
     }],
-    listAlertsForRepo: ["GET /repos/{owner}/{repo}/code-scanning/alerts"],
-    listRecentAnalyses: ["GET /repos/{owner}/{repo}/code-scanning/analyses"],
-    updateAlert: ["PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"],
-    uploadSarif: ["POST /repos/{owner}/{repo}/code-scanning/sarifs"]
+    createSuite: ["POST /repos/{owner}/{repo}/check-suites", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    get: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    getSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    listAnnotations: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    listForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-runs", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    listForSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    listSuitesForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-suites", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    rerequestSuite: ["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    setSuitesPreferences: ["PATCH /repos/{owner}/{repo}/check-suites/preferences", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }],
+    update: ["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}", {
+      mediaType: {
+        previews: ["antiope"]
+      }
+    }]
+  },
+  codeScanning: {
+    getAlert: ["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_id}"],
+    listAlertsForRepo: ["GET /repos/{owner}/{repo}/code-scanning/alerts"]
   },
   codesOfConduct: {
     getAllCodesOfConduct: ["GET /codes_of_conduct", {
@@ -2989,16 +3027,6 @@ const Endpoints = {
   },
   emojis: {
     get: ["GET /emojis"]
-  },
-  enterpriseAdmin: {
-    disableSelectedOrganizationGithubActionsEnterprise: ["DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"],
-    enableSelectedOrganizationGithubActionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"],
-    getAllowedActionsEnterprise: ["GET /enterprises/{enterprise}/actions/permissions/selected-actions"],
-    getGithubActionsPermissionsEnterprise: ["GET /enterprises/{enterprise}/actions/permissions"],
-    listSelectedOrganizationsEnabledGithubActionsEnterprise: ["GET /enterprises/{enterprise}/actions/permissions/organizations"],
-    setAllowedActionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions/selected-actions"],
-    setGithubActionsPermissionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions"],
-    setSelectedOrganizationsEnabledGithubActionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions/organizations"]
   },
   gists: {
     checkIsStarred: ["GET /gists/{gist_id}/star"],
@@ -3042,15 +3070,36 @@ const Endpoints = {
     getTemplate: ["GET /gitignore/templates/{name}"]
   },
   interactions: {
-    getRestrictionsForOrg: ["GET /orgs/{org}/interaction-limits"],
-    getRestrictionsForRepo: ["GET /repos/{owner}/{repo}/interaction-limits"],
-    getRestrictionsForYourPublicRepos: ["GET /user/interaction-limits"],
-    removeRestrictionsForOrg: ["DELETE /orgs/{org}/interaction-limits"],
-    removeRestrictionsForRepo: ["DELETE /repos/{owner}/{repo}/interaction-limits"],
-    removeRestrictionsForYourPublicRepos: ["DELETE /user/interaction-limits"],
-    setRestrictionsForOrg: ["PUT /orgs/{org}/interaction-limits"],
-    setRestrictionsForRepo: ["PUT /repos/{owner}/{repo}/interaction-limits"],
-    setRestrictionsForYourPublicRepos: ["PUT /user/interaction-limits"]
+    getRestrictionsForOrg: ["GET /orgs/{org}/interaction-limits", {
+      mediaType: {
+        previews: ["sombra"]
+      }
+    }],
+    getRestrictionsForRepo: ["GET /repos/{owner}/{repo}/interaction-limits", {
+      mediaType: {
+        previews: ["sombra"]
+      }
+    }],
+    removeRestrictionsForOrg: ["DELETE /orgs/{org}/interaction-limits", {
+      mediaType: {
+        previews: ["sombra"]
+      }
+    }],
+    removeRestrictionsForRepo: ["DELETE /repos/{owner}/{repo}/interaction-limits", {
+      mediaType: {
+        previews: ["sombra"]
+      }
+    }],
+    setRestrictionsForOrg: ["PUT /orgs/{org}/interaction-limits", {
+      mediaType: {
+        previews: ["sombra"]
+      }
+    }],
+    setRestrictionsForRepo: ["PUT /repos/{owner}/{repo}/interaction-limits", {
+      mediaType: {
+        previews: ["sombra"]
+      }
+    }]
   },
   issues: {
     addAssignees: ["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"],
@@ -3111,10 +3160,7 @@ const Endpoints = {
     }]
   },
   meta: {
-    get: ["GET /meta"],
-    getOctocat: ["GET /octocat"],
-    getZen: ["GET /zen"],
-    root: ["GET /"]
+    get: ["GET /meta"]
   },
   migrations: {
     cancelImport: ["DELETE /repos/{owner}/{repo}/import"],
@@ -3201,7 +3247,6 @@ const Endpoints = {
     getMembershipForAuthenticatedUser: ["GET /user/memberships/orgs/{org}"],
     getMembershipForUser: ["GET /orgs/{org}/memberships/{username}"],
     getWebhook: ["GET /orgs/{org}/hooks/{hook_id}"],
-    getWebhookConfigForOrg: ["GET /orgs/{org}/hooks/{hook_id}/config"],
     list: ["GET /organizations"],
     listAppInstallations: ["GET /orgs/{org}/installations"],
     listBlockedUsers: ["GET /orgs/{org}/blocks"],
@@ -3224,8 +3269,7 @@ const Endpoints = {
     unblockUser: ["DELETE /orgs/{org}/blocks/{username}"],
     update: ["PATCH /orgs/{org}"],
     updateMembershipForAuthenticatedUser: ["PATCH /user/memberships/orgs/{org}"],
-    updateWebhook: ["PATCH /orgs/{org}/hooks/{hook_id}"],
-    updateWebhookConfigForOrg: ["PATCH /orgs/{org}/hooks/{hook_id}/config"]
+    updateWebhook: ["PATCH /orgs/{org}/hooks/{hook_id}"]
   },
   projects: {
     addCollaborator: ["PUT /projects/{project_id}/collaborators/{username}", {
@@ -3456,7 +3500,7 @@ const Endpoints = {
         previews: ["squirrel-girl"]
       }
     }, {
-      deprecated: "octokit.reactions.deleteLegacy() is deprecated, see https://docs.github.com/v3/reactions/#delete-a-reaction-legacy"
+      deprecated: "octokit.reactions.deleteLegacy() is deprecated, see https://developer.github.com/v3/reactions/#delete-a-reaction-legacy"
     }],
     listForCommitComment: ["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions", {
       mediaType: {
@@ -3572,11 +3616,7 @@ const Endpoints = {
         previews: ["dorian"]
       }
     }],
-    downloadArchive: ["GET /repos/{owner}/{repo}/zipball/{ref}", {}, {
-      renamed: ["repos", "downloadZipballArchive"]
-    }],
-    downloadTarballArchive: ["GET /repos/{owner}/{repo}/tarball/{ref}"],
-    downloadZipballArchive: ["GET /repos/{owner}/{repo}/zipball/{ref}"],
+    downloadArchive: ["GET /repos/{owner}/{repo}/{archive_format}/{ref}"],
     enableAutomatedSecurityFixes: ["PUT /repos/{owner}/{repo}/automated-security-fixes", {
       mediaType: {
         previews: ["london"]
@@ -3611,7 +3651,11 @@ const Endpoints = {
         previews: ["zzzax"]
       }
     }],
-    getCommunityProfileMetrics: ["GET /repos/{owner}/{repo}/community/profile"],
+    getCommunityProfileMetrics: ["GET /repos/{owner}/{repo}/community/profile", {
+      mediaType: {
+        previews: ["black-panther"]
+      }
+    }],
     getContent: ["GET /repos/{owner}/{repo}/contents/{path}"],
     getContributorsStats: ["GET /repos/{owner}/{repo}/stats/contributors"],
     getDeployKey: ["GET /repos/{owner}/{repo}/keys/{key_id}"],
@@ -3635,7 +3679,6 @@ const Endpoints = {
     getUsersWithAccessToProtectedBranch: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"],
     getViews: ["GET /repos/{owner}/{repo}/traffic/views"],
     getWebhook: ["GET /repos/{owner}/{repo}/hooks/{hook_id}"],
-    getWebhookConfigForRepo: ["GET /repos/{owner}/{repo}/hooks/{hook_id}/config"],
     listBranches: ["GET /repos/{owner}/{repo}/branches"],
     listBranchesForHeadCommit: ["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head", {
       mediaType: {
@@ -3715,12 +3758,8 @@ const Endpoints = {
     updatePullRequestReviewProtection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"],
     updateRelease: ["PATCH /repos/{owner}/{repo}/releases/{release_id}"],
     updateReleaseAsset: ["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"],
-    updateStatusCheckPotection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks", {}, {
-      renamed: ["repos", "updateStatusCheckProtection"]
-    }],
-    updateStatusCheckProtection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"],
+    updateStatusCheckPotection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"],
     updateWebhook: ["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"],
-    updateWebhookConfigForRepo: ["PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config"],
     uploadReleaseAsset: ["POST /repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}", {
       baseUrl: "https://uploads.github.com"
     }]
@@ -3741,11 +3780,6 @@ const Endpoints = {
       }
     }],
     users: ["GET /search/users"]
-  },
-  secretScanning: {
-    getAlert: ["GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"],
-    listAlertsForRepo: ["GET /repos/{owner}/{repo}/secret-scanning/alerts"],
-    updateAlert: ["PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"]
   },
   teams: {
     addOrUpdateMembershipForUserInOrg: ["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"],
@@ -3827,7 +3861,7 @@ const Endpoints = {
   }
 };
 
-const VERSION = "4.4.1";
+const VERSION = "4.1.4";
 
 function endpointsToMethods(octokit, endpointsMap) {
   const newMethods = {};
@@ -4007,18 +4041,18 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var endpoint = __webpack_require__(440);
 var universalUserAgent = __webpack_require__(429);
-var isPlainObject = __webpack_require__(287);
+var isPlainObject = _interopDefault(__webpack_require__(886));
 var nodeFetch = _interopDefault(__webpack_require__(467));
 var requestError = __webpack_require__(537);
 
-const VERSION = "5.4.12";
+const VERSION = "5.4.7";
 
 function getBufferResponse(response) {
   return response.arrayBuffer();
 }
 
 function fetchWrapper(requestOptions) {
-  if (isPlainObject.isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
+  if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
     requestOptions.body = JSON.stringify(requestOptions.body);
   }
 
@@ -4147,6 +4181,50 @@ const request = withDefaults(endpoint.endpoint, {
 
 exports.request = request;
 //# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
+/***/ 886:
+/***/ ((module) => {
+
+"use strict";
+
+
+/*!
+ * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+function isObject(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
+}
+
+function isPlainObject(o) {
+  var ctor,prot;
+
+  if (isObject(o) === false) return false;
+
+  // If has modified constructor
+  ctor = o.constructor;
+  if (ctor === undefined) return true;
+
+  // If has modified prototype
+  prot = ctor.prototype;
+  if (isObject(prot) === false) return false;
+
+  // If constructor does not have an Object-specific method
+  if (prot.hasOwnProperty('isPrototypeOf') === false) {
+    return false;
+  }
+
+  // Most likely a plain Object
+  return true;
+}
+
+module.exports = isPlainObject;
 
 
 /***/ }),
@@ -4351,52 +4429,6 @@ class Deprecation extends Error {
 }
 
 exports.Deprecation = Deprecation;
-
-
-/***/ }),
-
-/***/ 287:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-/*!
- * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-function isObject(o) {
-  return Object.prototype.toString.call(o) === '[object Object]';
-}
-
-function isPlainObject(o) {
-  var ctor,prot;
-
-  if (isObject(o) === false) return false;
-
-  // If has modified constructor
-  ctor = o.constructor;
-  if (ctor === undefined) return true;
-
-  // If has modified prototype
-  prot = ctor.prototype;
-  if (isObject(prot) === false) return false;
-
-  // If constructor does not have an Object-specific method
-  if (prot.hasOwnProperty('isPrototypeOf') === false) {
-    return false;
-  }
-
-  // Most likely a plain Object
-  return true;
-}
-
-exports.isPlainObject = isPlainObject;
 
 
 /***/ }),
@@ -4941,25 +4973,14 @@ exports.isPlainObject = isPlainObject;
    * also be a function that is used to load partial templates on the fly
    * that takes a single argument: the name of the partial.
    *
-   * If the optional `config` argument is given here, then it should be an
-   * object with a `tags` attribute or an `escape` attribute or both.
-   * If an array is passed, then it will be interpreted the same way as
-   * a `tags` attribute on a `config` object.
-   *
-   * The `tags` attribute of a `config` object must be an array with two
+   * If the optional `tags` argument is given here it must be an array with two
    * string values: the opening and closing tags used in the template (e.g.
    * [ "<%", "%>" ]). The default is to mustache.tags.
-   *
-   * The `escape` attribute of a `config` object must be a function which
-   * accepts a string as input and outputs a safely escaped string.
-   * If an `escape` function is not provided, then an HTML-safe string
-   * escaping function is used as the default.
    */
-  Writer.prototype.render = function render (template, view, partials, config) {
-    var tags = this.getConfigTags(config);
+  Writer.prototype.render = function render (template, view, partials, tags) {
     var tokens = this.parse(template, tags);
     var context = (view instanceof Context) ? view : new Context(view, undefined);
-    return this.renderTokens(tokens, context, partials, template, config);
+    return this.renderTokens(tokens, context, partials, template, tags);
   };
 
   /**
@@ -4971,7 +4992,7 @@ exports.isPlainObject = isPlainObject;
    * If the template doesn't use higher-order sections, this argument may
    * be omitted.
    */
-  Writer.prototype.renderTokens = function renderTokens (tokens, context, partials, originalTemplate, config) {
+  Writer.prototype.renderTokens = function renderTokens (tokens, context, partials, originalTemplate, tags) {
     var buffer = '';
 
     var token, symbol, value;
@@ -4980,11 +5001,11 @@ exports.isPlainObject = isPlainObject;
       token = tokens[i];
       symbol = token[0];
 
-      if (symbol === '#') value = this.renderSection(token, context, partials, originalTemplate, config);
-      else if (symbol === '^') value = this.renderInverted(token, context, partials, originalTemplate, config);
-      else if (symbol === '>') value = this.renderPartial(token, context, partials, config);
+      if (symbol === '#') value = this.renderSection(token, context, partials, originalTemplate);
+      else if (symbol === '^') value = this.renderInverted(token, context, partials, originalTemplate);
+      else if (symbol === '>') value = this.renderPartial(token, context, partials, tags);
       else if (symbol === '&') value = this.unescapedValue(token, context);
-      else if (symbol === 'name') value = this.escapedValue(token, context, config);
+      else if (symbol === 'name') value = this.escapedValue(token, context);
       else if (symbol === 'text') value = this.rawValue(token);
 
       if (value !== undefined)
@@ -4994,7 +5015,7 @@ exports.isPlainObject = isPlainObject;
     return buffer;
   };
 
-  Writer.prototype.renderSection = function renderSection (token, context, partials, originalTemplate, config) {
+  Writer.prototype.renderSection = function renderSection (token, context, partials, originalTemplate) {
     var self = this;
     var buffer = '';
     var value = context.lookup(token[1]);
@@ -5002,17 +5023,17 @@ exports.isPlainObject = isPlainObject;
     // This function is used to render an arbitrary template
     // in the current context by higher-order sections.
     function subRender (template) {
-      return self.render(template, context, partials, config);
+      return self.render(template, context, partials);
     }
 
     if (!value) return;
 
     if (isArray(value)) {
       for (var j = 0, valueLength = value.length; j < valueLength; ++j) {
-        buffer += this.renderTokens(token[4], context.push(value[j]), partials, originalTemplate, config);
+        buffer += this.renderTokens(token[4], context.push(value[j]), partials, originalTemplate);
       }
     } else if (typeof value === 'object' || typeof value === 'string' || typeof value === 'number') {
-      buffer += this.renderTokens(token[4], context.push(value), partials, originalTemplate, config);
+      buffer += this.renderTokens(token[4], context.push(value), partials, originalTemplate);
     } else if (isFunction(value)) {
       if (typeof originalTemplate !== 'string')
         throw new Error('Cannot use higher-order sections without the original template');
@@ -5023,18 +5044,18 @@ exports.isPlainObject = isPlainObject;
       if (value != null)
         buffer += value;
     } else {
-      buffer += this.renderTokens(token[4], context, partials, originalTemplate, config);
+      buffer += this.renderTokens(token[4], context, partials, originalTemplate);
     }
     return buffer;
   };
 
-  Writer.prototype.renderInverted = function renderInverted (token, context, partials, originalTemplate, config) {
+  Writer.prototype.renderInverted = function renderInverted (token, context, partials, originalTemplate) {
     var value = context.lookup(token[1]);
 
     // Use JavaScript's definition of falsy. Include empty arrays.
     // See https://github.com/janl/mustache.js/issues/186
     if (!value || (isArray(value) && value.length === 0))
-      return this.renderTokens(token[4], context, partials, originalTemplate, config);
+      return this.renderTokens(token[4], context, partials, originalTemplate);
   };
 
   Writer.prototype.indentPartial = function indentPartial (partial, indentation, lineHasNonSpace) {
@@ -5048,9 +5069,8 @@ exports.isPlainObject = isPlainObject;
     return partialByNl.join('\n');
   };
 
-  Writer.prototype.renderPartial = function renderPartial (token, context, partials, config) {
+  Writer.prototype.renderPartial = function renderPartial (token, context, partials, tags) {
     if (!partials) return;
-    var tags = this.getConfigTags(config);
 
     var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
     if (value != null) {
@@ -5061,8 +5081,7 @@ exports.isPlainObject = isPlainObject;
       if (tagIndex == 0 && indentation) {
         indentedValue = this.indentPartial(value, indentation, lineHasNonSpace);
       }
-      var tokens = this.parse(indentedValue, tags);
-      return this.renderTokens(tokens, context, partials, indentedValue, config);
+      return this.renderTokens(this.parse(indentedValue, tags), context, partials, indentedValue, tags);
     }
   };
 
@@ -5072,41 +5091,19 @@ exports.isPlainObject = isPlainObject;
       return value;
   };
 
-  Writer.prototype.escapedValue = function escapedValue (token, context, config) {
-    var escape = this.getConfigEscape(config) || mustache.escape;
+  Writer.prototype.escapedValue = function escapedValue (token, context) {
     var value = context.lookup(token[1]);
     if (value != null)
-      return (typeof value === 'number' && escape === mustache.escape) ? String(value) : escape(value);
+      return mustache.escape(value);
   };
 
   Writer.prototype.rawValue = function rawValue (token) {
     return token[1];
   };
 
-  Writer.prototype.getConfigTags = function getConfigTags (config) {
-    if (isArray(config)) {
-      return config;
-    }
-    else if (config && typeof config === 'object') {
-      return config.tags;
-    }
-    else {
-      return undefined;
-    }
-  };
-
-  Writer.prototype.getConfigEscape = function getConfigEscape (config) {
-    if (config && typeof config === 'object' && !isArray(config)) {
-      return config.escape;
-    }
-    else {
-      return undefined;
-    }
-  };
-
   var mustache = {
     name: 'mustache.js',
-    version: '4.1.0',
+    version: '4.0.1',
     tags: [ '{{', '}}' ],
     clearCache: undefined,
     escape: undefined,
@@ -5151,17 +5148,19 @@ exports.isPlainObject = isPlainObject;
   };
 
   /**
-   * Renders the `template` with the given `view`, `partials`, and `config`
-   * using the default writer.
+   * Renders the `template` with the given `view` and `partials` using the
+   * default writer. If the optional `tags` argument is given here it must be an
+   * array with two string values: the opening and closing tags used in the
+   * template (e.g. [ "<%", "%>" ]). The default is to mustache.tags.
    */
-  mustache.render = function render (template, view, partials, config) {
+  mustache.render = function render (template, view, partials, tags) {
     if (typeof template !== 'string') {
       throw new TypeError('Invalid template! Template should be a "string" ' +
                           'but "' + typeStr(template) + '" was given as the first ' +
                           'argument for mustache#render(template, view, partials)');
     }
 
-    return defaultWriter.render(template, view, partials, config);
+    return defaultWriter.render(template, view, partials, tags);
   };
 
   // Export the escaping function so that the user may override it.
@@ -7244,7 +7243,7 @@ module.exports = eval("require")("encoding");
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("assert");;
+module.exports = require("assert");
 
 /***/ }),
 
@@ -7252,7 +7251,7 @@ module.exports = require("assert");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("events");;
+module.exports = require("events");
 
 /***/ }),
 
@@ -7260,7 +7259,7 @@ module.exports = require("events");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("fs");;
+module.exports = require("fs");
 
 /***/ }),
 
@@ -7268,7 +7267,7 @@ module.exports = require("fs");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("http");;
+module.exports = require("http");
 
 /***/ }),
 
@@ -7276,7 +7275,7 @@ module.exports = require("http");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("https");;
+module.exports = require("https");
 
 /***/ }),
 
@@ -7284,7 +7283,7 @@ module.exports = require("https");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("net");;
+module.exports = require("net");
 
 /***/ }),
 
@@ -7292,7 +7291,7 @@ module.exports = require("net");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("os");;
+module.exports = require("os");
 
 /***/ }),
 
@@ -7300,7 +7299,7 @@ module.exports = require("os");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("path");;
+module.exports = require("path");
 
 /***/ }),
 
@@ -7308,7 +7307,7 @@ module.exports = require("path");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("stream");;
+module.exports = require("stream");
 
 /***/ }),
 
@@ -7316,7 +7315,7 @@ module.exports = require("stream");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("tls");;
+module.exports = require("tls");
 
 /***/ }),
 
@@ -7324,7 +7323,7 @@ module.exports = require("tls");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("url");;
+module.exports = require("url");
 
 /***/ }),
 
@@ -7332,7 +7331,7 @@ module.exports = require("url");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("util");;
+module.exports = require("util");
 
 /***/ }),
 
@@ -7340,7 +7339,7 @@ module.exports = require("util");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("zlib");;
+module.exports = require("zlib");
 
 /***/ })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -492,6 +492,7 @@ function createClubhouseStory(payload, http) {
             return null;
         }
         const githubLabels = (payload.pull_request.labels || []).map((label) => label.name);
+        core.debug(`PR: ${JSON.stringify(payload.pull_request)}`);
         core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
         core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
         const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);

--- a/dist/index.js
+++ b/dist/index.js
@@ -134,10 +134,8 @@ const util_1 = __webpack_require__(24);
 function labeled() {
     return __awaiter(this, void 0, void 0, function* () {
         const payload = github_1.context.payload;
-        // TODO: grab labels. can we tell which label was added in the event?
         // Do this up front because we want to return fast if the new label was not
         // configured for Iteration support
-        core.debug(`payload: ${JSON.stringify(payload)}`);
         core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
         const newGithubLabel = payload.label ? payload.label.name : undefined;
         core.debug(`newGithubLabel: ${newGithubLabel}`);
@@ -154,8 +152,6 @@ function labeled() {
         if (storyId) {
             core.debug(`found story ID ${storyId} in branch ${branchName}`);
         }
-        // TODO: Does timing work out such that we can expect to have the CH
-        // story comment posted already when the label event fires?
         const clubhouseURL = yield util_1.getClubhouseURLFromPullRequest(payload);
         if (!clubhouseURL) {
             core.setFailed("Clubhouse URL not found!");
@@ -164,7 +160,6 @@ function labeled() {
         const match = clubhouseURL.match(util_1.CLUBHOUSE_STORY_URL_REGEXP);
         if (match) {
             storyId = match[1];
-            core.setOutput("story-id", storyId);
         }
         else {
             core.debug(`invalid Clubhouse URL: ${clubhouseURL}`);
@@ -182,9 +177,10 @@ function labeled() {
             yield util_1.updateClubhouseStoryById(storyId, http, {
                 iteration_id: clubhouseIteration.id,
             });
+            core.setOutput("iteration-url", clubhouseIteration.app_url);
+            core.setOutput("iteration-name", clubhouseIteration.name);
         }
         else {
-            // TODO: should this really be a failure?
             core.setFailed(`Could not find Clubhouse Iteration for story`);
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -142,11 +142,13 @@ function labeled() {
         const newGithubLabel = payload.label ? payload.label.name : undefined;
         core.debug(`newGithubLabel: ${newGithubLabel}`);
         const clubhouseIterationInfo = util_1.getClubhouseIterationInfo(newGithubLabel);
-        core.debug(`ClubhouseIterationInfo: ${clubhouseIterationInfo}`);
+        core.debug(`ClubhouseIterationInfo: ${JSON.stringify(clubhouseIterationInfo)}`);
         if (!clubhouseIterationInfo) {
             core.debug(`No new label configured for iteration matching. Done!`);
             return;
         }
+        core.debug(`Waiting 10s to ensure CH ticket has been created`);
+        yield util_1.delay(10000);
         const branchName = payload.pull_request.head.ref;
         let storyId = util_1.getClubhouseStoryIdFromBranchName(branchName);
         if (storyId) {
@@ -377,7 +379,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getClubhouseIterationInfo = exports.getLatestMatchingClubhouseIteration = exports.updateClubhouseStoryById = exports.addCommentToPullRequest = exports.getClubhouseURLFromPullRequest = exports.getClubhouseStoryIdFromBranchName = exports.createClubhouseStory = exports.getClubhouseWorkflowState = exports.getClubhouseProjectByName = exports.getClubhouseProject = exports.getClubhouseStoryById = exports.getClubhouseUserId = exports.getUserListAsSet = exports.shouldProcessPullRequestForUser = exports.CLUBHOUSE_BRANCH_NAME_REGEXP = exports.CLUBHOUSE_STORY_URL_REGEXP = void 0;
+exports.delay = exports.getClubhouseIterationInfo = exports.getLatestMatchingClubhouseIteration = exports.updateClubhouseStoryById = exports.addCommentToPullRequest = exports.getClubhouseURLFromPullRequest = exports.getClubhouseStoryIdFromBranchName = exports.createClubhouseStory = exports.getClubhouseWorkflowState = exports.getClubhouseProjectByName = exports.getClubhouseProject = exports.getClubhouseStoryById = exports.getClubhouseUserId = exports.getUserListAsSet = exports.shouldProcessPullRequestForUser = exports.CLUBHOUSE_BRANCH_NAME_REGEXP = exports.CLUBHOUSE_STORY_URL_REGEXP = void 0;
 const core = __importStar(__webpack_require__(186));
 const github = __importStar(__webpack_require__(438));
 const mustache_1 = __importDefault(__webpack_require__(272));
@@ -754,7 +756,6 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
 exports.getLatestMatchingClubhouseIteration = getLatestMatchingClubhouseIteration;
 function getClubhouseIterationInfo(githubLabel) {
     const LABEL_MAP_STRING = core.getInput("label-iteration-group-map");
-    core.debug(`LABEL_MAP_STRING: ${LABEL_MAP_STRING}`);
     if (!githubLabel) {
         return;
     }
@@ -778,6 +779,11 @@ function getClubhouseIterationInfo(githubLabel) {
     return;
 }
 exports.getClubhouseIterationInfo = getClubhouseIterationInfo;
+/* Use with caution! Only to resolve potential races in event handling */
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+exports.delay = delay;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -2149,7 +2149,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var isPlainObject = _interopDefault(__webpack_require__(38));
+var isPlainObject = _interopDefault(__webpack_require__(810));
 var universalUserAgent = __webpack_require__(429);
 
 function lowercaseKeys(object) {
@@ -2522,50 +2522,6 @@ const endpoint = withDefaults(null, DEFAULTS);
 
 exports.endpoint = endpoint;
 //# sourceMappingURL=index.js.map
-
-
-/***/ }),
-
-/***/ 38:
-/***/ ((module) => {
-
-"use strict";
-
-
-/*!
- * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-function isObject(o) {
-  return Object.prototype.toString.call(o) === '[object Object]';
-}
-
-function isPlainObject(o) {
-  var ctor,prot;
-
-  if (isObject(o) === false) return false;
-
-  // If has modified constructor
-  ctor = o.constructor;
-  if (ctor === undefined) return true;
-
-  // If has modified prototype
-  prot = ctor.prototype;
-  if (isObject(prot) === false) return false;
-
-  // If constructor does not have an Object-specific method
-  if (prot.hasOwnProperty('isPrototypeOf') === false) {
-    return false;
-  }
-
-  // Most likely a plain Object
-  return true;
-}
-
-module.exports = isPlainObject;
 
 
 /***/ }),
@@ -4041,7 +3997,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var endpoint = __webpack_require__(440);
 var universalUserAgent = __webpack_require__(429);
-var isPlainObject = _interopDefault(__webpack_require__(886));
+var isPlainObject = _interopDefault(__webpack_require__(810));
 var nodeFetch = _interopDefault(__webpack_require__(467));
 var requestError = __webpack_require__(537);
 
@@ -4181,50 +4137,6 @@ const request = withDefaults(endpoint.endpoint, {
 
 exports.request = request;
 //# sourceMappingURL=index.js.map
-
-
-/***/ }),
-
-/***/ 886:
-/***/ ((module) => {
-
-"use strict";
-
-
-/*!
- * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-function isObject(o) {
-  return Object.prototype.toString.call(o) === '[object Object]';
-}
-
-function isPlainObject(o) {
-  var ctor,prot;
-
-  if (isObject(o) === false) return false;
-
-  // If has modified constructor
-  ctor = o.constructor;
-  if (ctor === undefined) return true;
-
-  // If has modified prototype
-  prot = ctor.prototype;
-  if (isObject(prot) === false) return false;
-
-  // If constructor does not have an Object-specific method
-  if (prot.hasOwnProperty('isPrototypeOf') === false) {
-    return false;
-  }
-
-  // Most likely a plain Object
-  return true;
-}
-
-module.exports = isPlainObject;
 
 
 /***/ }),
@@ -4429,6 +4341,71 @@ class Deprecation extends Error {
 }
 
 exports.Deprecation = Deprecation;
+
+
+/***/ }),
+
+/***/ 810:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+"use strict";
+/*!
+ * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+var isObject = __webpack_require__(509);
+
+function isObjectObject(o) {
+  return isObject(o) === true
+    && Object.prototype.toString.call(o) === '[object Object]';
+}
+
+module.exports = function isPlainObject(o) {
+  var ctor,prot;
+
+  if (isObjectObject(o) === false) return false;
+
+  // If has modified constructor
+  ctor = o.constructor;
+  if (typeof ctor !== 'function') return false;
+
+  // If has modified prototype
+  prot = ctor.prototype;
+  if (isObjectObject(prot) === false) return false;
+
+  // If constructor does not have an Object-specific method
+  if (prot.hasOwnProperty('isPrototypeOf') === false) {
+    return false;
+  }
+
+  // Most likely a plain Object
+  return true;
+};
+
+
+/***/ }),
+
+/***/ 509:
+/***/ ((module) => {
+
+"use strict";
+/*!
+ * isobject <https://github.com/jonschlinkert/isobject>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+module.exports = function isObject(val) {
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+};
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -777,7 +777,7 @@ function getClubhouseIterationInfo(githubLabel) {
 exports.getClubhouseIterationInfo = getClubhouseIterationInfo;
 /* Use with caution! Only to resolve potential races in event handling */
 function delay(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 exports.delay = delay;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -492,7 +492,7 @@ function createClubhouseStory(payload, http) {
             return null;
         }
         const githubLabels = (payload.pull_request.labels || []).map((label) => label.name);
-        core.debug(`PR: ${JSON.stringify(payload.pull_request)}`);
+        core.debug(`payload: ${JSON.stringify(payload)}`);
         core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
         core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
         const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);

--- a/dist/index.js
+++ b/dist/index.js
@@ -766,10 +766,13 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
 exports.getLatestMatchingClubhouseIteration = getLatestMatchingClubhouseIteration;
 function getClubhouseIterationInfo(githubLabels) {
     const LABEL_MAP_STRING = core.getInput("label-iteration-group-map");
+    core.debug(`LABEL_MAP_STRING: ${LABEL_MAP_STRING}`);
     if (LABEL_MAP_STRING) {
         try {
             const LABEL_MAP = JSON.parse(LABEL_MAP_STRING);
+            core.debug(`LABEL_MAP (parsed): ${LABEL_MAP}`);
             for (const label in githubLabels) {
+                core.debug(`Looking for map entry matching label '${label}'`);
                 const info = LABEL_MAP[label];
                 if (info) {
                     if (!info.groupId) {

--- a/src/labeled.ts
+++ b/src/labeled.ts
@@ -1,0 +1,76 @@
+import * as core from "@actions/core";
+import { context } from "@actions/github";
+import { EventPayloads } from "@octokit/webhooks";
+import { HttpClient } from "@actions/http-client";
+import {
+  CLUBHOUSE_STORY_URL_REGEXP,
+  getClubhouseURLFromPullRequest,
+  getClubhouseStoryIdFromBranchName,
+  getClubhouseStoryById,
+  updateClubhouseStoryById,
+  getClubhouseIterationInfo,
+  getLatestMatchingClubhouseIteration,
+} from "./util";
+
+export default async function labeled(): Promise<void> {
+  const payload = context.payload as EventPayloads.WebhookPayloadPullRequest;
+
+  // TODO: grab labels. can we tell which label was added in the event?
+  // Do this up front because we want to return fast if a PR has no labels
+  // configured for Iteration support
+  core.debug(`payload: ${JSON.stringify(payload)}`);
+  core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
+  const githubLabels = (payload.pull_request.labels || []).map(
+    (label) => label.name
+  );
+  core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
+  const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
+  if (!clubhouseIterationInfo) {
+    core.debug(`No new label configured for iteration matching. Done!`);
+    return;
+  }
+
+  const branchName = payload.pull_request.head.ref;
+  let storyId = getClubhouseStoryIdFromBranchName(branchName);
+  if (storyId) {
+    core.debug(`found story ID ${storyId} in branch ${branchName}`);
+  }
+
+  // TODO: Does timing work out such that we can expect to have the CH
+  // story comment posted already when the label event fires?
+  const clubhouseURL = await getClubhouseURLFromPullRequest(payload);
+  if (!clubhouseURL) {
+    core.setFailed("Clubhouse URL not found!");
+    return;
+  }
+
+  const match = clubhouseURL.match(CLUBHOUSE_STORY_URL_REGEXP);
+  if (match) {
+    storyId = match[1];
+    core.setOutput("story-id", storyId);
+  } else {
+    core.debug(`invalid Clubhouse URL: ${clubhouseURL}`);
+    return;
+  }
+
+  const http = new HttpClient();
+  const story = await getClubhouseStoryById(storyId, http);
+  if (!story) {
+    core.setFailed(`Could not get Clubhouse story ${storyId}`);
+    return;
+  }
+
+  const clubhouseIteration = await getLatestMatchingClubhouseIteration(
+    clubhouseIterationInfo,
+    http
+  );
+  core.debug(`clubhouseIteration: ${JSON.stringify(clubhouseIteration)}`);
+  if (clubhouseIteration) {
+    await updateClubhouseStoryById(storyId, http, {
+      iteration_id:  clubhouseIteration.id,
+    });
+  } else {
+    // TODO: should this really be a failure?
+    core.setFailed(`Could not find Clubhouse Iteration for story`);
+  }
+}

--- a/src/labeled.ts
+++ b/src/labeled.ts
@@ -22,7 +22,9 @@ export default async function labeled(): Promise<void> {
   const newGithubLabel = payload.label ? payload.label.name : undefined;
   core.debug(`newGithubLabel: ${newGithubLabel}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(newGithubLabel);
-  core.debug(`ClubhouseIterationInfo: ${JSON.stringify(clubhouseIterationInfo)}`);
+  core.debug(
+    `ClubhouseIterationInfo: ${JSON.stringify(clubhouseIterationInfo)}`
+  );
   if (!clubhouseIterationInfo) {
     core.debug(`No new label configured for iteration matching. Done!`);
     return;
@@ -64,7 +66,7 @@ export default async function labeled(): Promise<void> {
   core.debug(`clubhouseIteration: ${JSON.stringify(clubhouseIteration)}`);
   if (clubhouseIteration) {
     await updateClubhouseStoryById(storyId, http, {
-      iteration_id:  clubhouseIteration.id,
+      iteration_id: clubhouseIteration.id,
     });
     core.setOutput("iteration-url", clubhouseIteration.app_url);
     core.setOutput("iteration-name", clubhouseIteration.name);

--- a/src/labeled.ts
+++ b/src/labeled.ts
@@ -10,6 +10,7 @@ import {
   updateClubhouseStoryById,
   getClubhouseIterationInfo,
   getLatestMatchingClubhouseIteration,
+  delay,
 } from "./util";
 
 export default async function labeled(): Promise<void> {
@@ -23,12 +24,14 @@ export default async function labeled(): Promise<void> {
   const newGithubLabel = payload.label ? payload.label.name : undefined;
   core.debug(`newGithubLabel: ${newGithubLabel}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(newGithubLabel);
-  core.debug(`ClubhouseIterationInfo: ${clubhouseIterationInfo}`);
+  core.debug(`ClubhouseIterationInfo: ${JSON.stringify(clubhouseIterationInfo)}`);
   if (!clubhouseIterationInfo) {
     core.debug(`No new label configured for iteration matching. Done!`);
     return;
   }
 
+  core.debug(`Waiting 10s to ensure CH ticket has been created`);
+  await delay(10000);
   const branchName = payload.pull_request.head.ref;
   let storyId = getClubhouseStoryIdFromBranchName(branchName);
   if (storyId) {

--- a/src/labeled.ts
+++ b/src/labeled.ts
@@ -16,15 +16,14 @@ export default async function labeled(): Promise<void> {
   const payload = context.payload as EventPayloads.WebhookPayloadPullRequest;
 
   // TODO: grab labels. can we tell which label was added in the event?
-  // Do this up front because we want to return fast if a PR has no labels
+  // Do this up front because we want to return fast if the new label was not
   // configured for Iteration support
   core.debug(`payload: ${JSON.stringify(payload)}`);
   core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
-  const githubLabels = (payload.pull_request.labels || []).map(
-    (label) => label.name
-  );
-  core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
-  const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
+  const newGithubLabel = payload.label ? payload.label.name : undefined;
+  core.debug(`newGithubLabel: ${newGithubLabel}`);
+  const clubhouseIterationInfo = getClubhouseIterationInfo(newGithubLabel);
+  core.debug(`ClubhouseIterationInfo: ${clubhouseIterationInfo}`);
   if (!clubhouseIterationInfo) {
     core.debug(`No new label configured for iteration matching. Done!`);
     return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { context } from "@actions/github";
 import { EventPayloads } from "@octokit/webhooks";
 import opened from "./opened";
 import closed from "./closed";
+import labeled from "./labeled";
 import { shouldProcessPullRequestForUser } from "./util";
 
 async function run(): Promise<void> {
@@ -21,9 +22,11 @@ async function run(): Promise<void> {
       return opened();
     case "closed":
       return closed();
+    case "labeled":
+      return labeled();
     default:
       core.setFailed(
-        "This action only works with the `opened` and `closed` actions for `pull_request` events"
+        "This action only works with the `opened`, `closed` and `labeled` actions for `pull_request` events"
       );
       return;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -526,14 +526,17 @@ export function getClubhouseIterationInfo(
   githubLabels: string[]
 ): IterationInfo | undefined {
   const LABEL_MAP_STRING = core.getInput("label-iteration-group-map");
+  core.debug(`LABEL_MAP_STRING: ${LABEL_MAP_STRING}`);
   if (LABEL_MAP_STRING) {
     try {
       const LABEL_MAP = JSON.parse(LABEL_MAP_STRING) as Record<
         string,
         IterationInfo
       >;
+      core.debug(`LABEL_MAP (parsed): ${LABEL_MAP}`);
 
       for (const label in githubLabels) {
+        core.debug(`Looking for map entry matching label '${label}'`);
         const info = LABEL_MAP[label];
         if (info) {
           if (!info.groupId) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -299,7 +299,7 @@ export async function createClubhouseStory(
   const githubLabels = (payload.pull_request.labels || []).map(
     (label) => label.name
   );
-  core.debug(`PR: ${JSON.stringify(payload.pull_request)}`);
+  core.debug(`payload: ${JSON.stringify(payload)}`);
   core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
   core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);

--- a/src/util.ts
+++ b/src/util.ts
@@ -508,7 +508,6 @@ export function getClubhouseIterationInfo(
   githubLabel: string | undefined,
 ): IterationInfo | undefined {
   const LABEL_MAP_STRING = core.getInput("label-iteration-group-map");
-  core.debug(`LABEL_MAP_STRING: ${LABEL_MAP_STRING}`);
   if (!githubLabel) {
     return;
   }
@@ -535,4 +534,11 @@ export function getClubhouseIterationInfo(
     }
   }
   return;
+}
+
+/* Use with caution! Only to resolve potential races in event handling */
+export function delay(
+  ms: number,
+): Promise<typeof setTimeout> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -299,9 +299,10 @@ export async function createClubhouseStory(
   const githubLabels = (payload.pull_request.labels || []).map(
     (label) => label.name
   );
-  core.debug(`githubLabels: ${githubLabels}`);
+  core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
+  core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
-  core.debug(`clubhouseIterationInfo: ${clubhouseIterationInfo}`);
+  core.debug(`clubhouseIterationInfo: ${JSON.stringify(clubhouseIterationInfo)}`);
   const body: ClubhouseCreateStoryBody = {
     name: title,
     description,
@@ -321,7 +322,7 @@ export async function createClubhouseStory(
       clubhouseIterationInfo,
       http
     );
-    core.debug(`clubhouseIteration: ${clubhouseIteration}`);
+    core.debug(`clubhouseIteration: ${JSON.stringify(clubhouseIteration)}`);
     if (clubhouseIteration) {
       body.iteration_id = clubhouseIteration.id;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -299,6 +299,7 @@ export async function createClubhouseStory(
   const githubLabels = (payload.pull_request.labels || []).map(
     (label) => label.name
   );
+  core.debug(`PR: ${JSON.stringify(payload.pull_request)}`);
   core.debug(`PR labels: ${JSON.stringify(payload.pull_request.labels)}`);
   core.debug(`githubLabels: ${JSON.stringify(githubLabels)}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);

--- a/src/util.ts
+++ b/src/util.ts
@@ -505,7 +505,7 @@ export async function getLatestMatchingClubhouseIteration(
 }
 
 export function getClubhouseIterationInfo(
-  githubLabel: string | undefined,
+  githubLabel: string | undefined
 ): IterationInfo | undefined {
   const LABEL_MAP_STRING = core.getInput("label-iteration-group-map");
   if (!githubLabel) {
@@ -537,8 +537,6 @@ export function getClubhouseIterationInfo(
 }
 
 /* Use with caution! Only to resolve potential races in event handling */
-export function delay(
-  ms: number,
-): Promise<typeof setTimeout> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+export function delay(ms: number): Promise<typeof setTimeout> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -299,7 +299,9 @@ export async function createClubhouseStory(
   const githubLabels = (payload.pull_request.labels || []).map(
     (label) => label.name
   );
+  core.debug(`githubLabels: ${githubLabels}`);
   const clubhouseIterationInfo = getClubhouseIterationInfo(githubLabels);
+  core.debug(`clubhouseIterationInfo: ${clubhouseIterationInfo}`);
   const body: ClubhouseCreateStoryBody = {
     name: title,
     description,
@@ -319,6 +321,7 @@ export async function createClubhouseStory(
       clubhouseIterationInfo,
       http
     );
+    core.debug(`clubhouseIteration: ${clubhouseIteration}`);
     if (clubhouseIteration) {
       body.iteration_id = clubhouseIteration.id;
     }


### PR DESCRIPTION
It turns out that when a PR is first created, it has no labels. Labels
are added in a separate API call after PR creation, and thus in order
to add an iteration based on a label, it must be in a 'labeled' event
handler, not 'opened' as I initially attempted. This PR moves the logic
for assigning the iteration to the separate 'labeled' event trigger.

There is one dubious thing, which is adding a 10s delay in the 'labeled'
handler. This is because GitHub launches all of the actions at the same
time, and if the Clubhouse ticket has not been created before we try to
look up the associated ticket to update the iteration on, the labeled handler
will fail. Ideally we could determine an execution order, but I don't see
a way to do that.

Note: GitHub will fire a _separate_ action for each label added. The code
will exit ASAP if no iteration team is configured for the label. This means
we do not waste much actions time on these other labels. (2s each or so)