### PR TITLE
Allow for hyphens in org name in story regex

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -263,6 +263,24 @@ test("getClubhouseURLFromPullRequest desc", async () => {
   expect(url).toEqual("https://app.clubhouse.io/org/story/12345");
 });
 
+test("getClubhouseURLFromPullRequest desc hyphens", async () => {
+  const payload = {
+    pull_request: {
+      body: "Clubhouse story: https://app.clubhouse.io/org-org/story/12345",
+      number: 123,
+    },
+    repository: {
+      owner: {
+        login: "octocat",
+      },
+      name: "example",
+    },
+  };
+
+  const url = await util.getClubhouseURLFromPullRequest(payload as any);
+  expect(url).toEqual("https://app.clubhouse.io/org-org/story/12345");
+});
+
 test("getClubhouseURLFromPullRequest comment", async () => {
   const payload = {
     pull_request: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -369,7 +369,7 @@ exports.delay = exports.getClubhouseIterationInfo = exports.getLatestMatchingClu
 const core = __importStar(__webpack_require__(186));
 const github = __importStar(__webpack_require__(438));
 const mustache_1 = __importDefault(__webpack_require__(272));
-exports.CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
+exports.CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/[\w-]+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
 exports.CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?ch(\d+)(?:[-/].+)?$/;
 /**
  * Convert a Map to a sorted string representation. Useful for debugging.

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,7 +14,7 @@ import {
   ClubhouseIterationSlim,
 } from "./types";
 
-export const CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
+export const CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/[\w-]+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
 export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?ch(\d+)(?:[-/].+)?$/;
 
 interface Stringable {


### PR DESCRIPTION
We have a hyphen in or org name in clubhouse that this regex was breaking on.  This fixes that edge case.