### PR TITLE
Looking for sc- instead of ch in branch name patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ _before_ the pull request is created.
 
 This Action will specifically check for branch names that follow the naming
 convention for this built-in integration. Any branch name that contains
-`ch####` will be ignored by this Action, on the assumption that a Clubhouse
-story already exists for the pull request. The `ch####` must be separated
+`sc-####` will be ignored by this Action, on the assumption that a Clubhouse
+story already exists for the pull request. The `sc-####` must be separated
 from leading or following text with either a `/` or a `-`. So, branches
-named `ch1`, `prefix/ch23`, `prefix-ch123`, `ch3456/suffix`, `ch3456-suffux`,
-`prefix/ch987/suffix` would match, but `xch123` and `ch987end` would not.
+named `sc-1`, `prefix/sc-23`, `prefix-sc-123`, `sc-3456/suffix`, `sc-3456-suffux`,
+`prefix/sc-987/suffix` would match, but `xsc-123` and `sc-987end` would not.
 
 ## Customizing the Pull Request Comment
 
@@ -180,7 +180,7 @@ Multiple users should be separated by commas.
 ## Iteration Support
 
 Clubhouse supports the concept of [iterations](https://help.clubhouse.io/hc/en-us/articles/360028953452-Iterations-Overview)
- -- time-boxed periods of development for stories. You can configure this Action
+-- time-boxed periods of development for stories. You can configure this Action
 to automatically assign the Clubhouse stories it creates to Clubhouse iterations,
 using GitHub labels and Clubhouse groups to identify the correct iteration to use.
 
@@ -189,7 +189,7 @@ the way you use Clubhouse and GitHub:
 
 - We assume that each team has an associated [Clubhouse group](https://help.clubhouse.io/hc/en-us/articles/360039328751-Groups-Group-Management),
   and that Clubhouse iterations are associated with this group.
-- We assume that the correct iteration to use is the *most recent*
+- We assume that the correct iteration to use is the _most recent_
   in-progress iteration for the group, as determined by the "last updated" time.
   (However, you may exclude specific iterations by name.)
 - We assume that each team has an associated [GitHub label](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/managing-labels),
@@ -198,7 +198,7 @@ the way you use Clubhouse and GitHub:
   [Labeler Action](https://github.com/actions/labeler).)
 
 If you want to use this feature, and you have a different workflow that
-does *not* match these assumptions, open a GitHub Issue on this repo
+does _not_ match these assumptions, open a GitHub Issue on this repo
 and let's talk about it! Maybe we can find a way to make this Action
 support other workflows, as well.
 

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -199,21 +199,21 @@ describe("createClubhouseStory", () => {
 });
 
 test.each([
-  ["ch1", "1"],
-  ["ch89/something", "89"],
-  ["ch99-something", "99"],
-  ["prefix-1/ch123", "123"],
-  ["prefix-1-ch321", "321"],
-  ["prefix/ch5678/suffix", "5678"],
-  ["prefix-ch6789/suffix-more", "6789"],
-  ["prefix/ch7890-suffix", "7890"],
-  ["prefix-ch0987-suffix-extra", "0987"],
+  ["sc-1", "1"],
+  ["sc-89/something", "89"],
+  ["sc-99-something", "99"],
+  ["prefix-1/sc-123", "123"],
+  ["prefix-1-sc-321", "321"],
+  ["prefix/sc-5678/suffix", "5678"],
+  ["prefix-sc-6789/suffix-more", "6789"],
+  ["prefix/sc-7890-suffix", "7890"],
+  ["prefix-sc-0987-suffix-extra", "0987"],
 ])("getClubhouseStoryIdFromBranchName matches %s", (branch, expected) => {
   const id = util.getClubhouseStoryIdFromBranchName(branch);
   expect(id).toEqual(expected);
 });
 
-test.each(["prefix/ch8765+suffix", "ch554X", "ach8765", "this_ch1234"])(
+test.each(["prefix/sc-8765+suffix", "sc-554X", "asc-8765", "this_sc-1234"])(
   "getClubhouseStoryIdFromBranchName does not match %s",
   (branch) => {
     const id = util.getClubhouseStoryIdFromBranchName(branch);

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,7 @@ import {
 
 export const CLUBHOUSE_STORY_URL_REGEXP =
   /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
-export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?ch(\d+)(?:[-/].+)?$/;
+export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?sc\-(\d+)(?:[-/].+)?$/;
 
 interface Stringable {
   toString(): string;


### PR DESCRIPTION
To reflect a [pretty zany decision to rename their company](https://shortcut.com/blog/clubhouse-changing-our-name-to-shortcut), Clubhouse (now shortcut) has also changed their branch matching patterns from `ch####` to `sc-####`:

![CleanShot 2021-09-15 at 10 52 46](https://user-images.githubusercontent.com/713991/133456894-33405314-91fe-4f47-a037-e394ce0634b6.png)

This PR updates tests and the matching regex to accommodate the new convention.

---
PS DB hope you're well!