### PR TITLE
Update package to work with current shortcut.com migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Create Linked Clubhouse Story
 
 This is a [GitHub Action](https://github.com/features/actions) that will
-automatically create a story on [Clubhouse](https://clubhouse.io/) when
+automatically create a story on [Clubhouse](https://shortcut.com/) when
 a pull request is opened, unless the pull request already has a link to
 a Clubhouse story in the description.
 
 ## Basic Usage
 
-[Create a Clubhouse API token](https://app.clubhouse.io/settings/account/api-tokens),
+[Create a Clubhouse API token](https://app.shortcut.com/settings/account/api-tokens),
 and store it as an encrypted secret in your GitHub repository settings.
 [Check the GitHub documentation for how to create an encrypted secret.](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets)
 Name this secret `CLUBHOUSE_TOKEN`.
@@ -41,7 +41,7 @@ be in when the pull request is opened, merged, and closed, respectively.
 
 ## Disabled for Built-In Integration
 
-[Clubhouse already has an integration with GitHub.](https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration)
+[Clubhouse already has an integration with GitHub.](https://help.shortcut.com/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration)
 It works for the opposite use-case, assuming that the Clubhouse story exists
 _before_ the pull request is created.
 
@@ -73,7 +73,7 @@ variable, like this:
 ```
 
 This comment template is processed using the [Mustache](https://mustache.github.io/)
-templating system. It receives [the Story object returned from the Clubhouse API](https://clubhouse.io/api/rest/v3/#Story). Note that you may want to use the
+templating system. It receives [the Story object returned from the Clubhouse API](https://shortcut.com/api/rest/v3/#Story). Note that you may want to use the
 triple mustache syntax to disable HTML escaping.
 
 GitHub will automatically process the comment text as [Markdown](https://guides.github.com/features/mastering-markdown/),
@@ -142,9 +142,9 @@ formatted string. Here's an example:
 The keys of this JSON object must be GitHub usernames, while the values
 must be Clubhouse UUIDs that identify members. Unfortunately, these UUIDs
 are not exposed on the Clubhouse website; the best way to look them up is to
-[go to the User Directory for your Clubhouse workspace](https://app.clubhouse.io/settings/users),
+[go to the User Directory for your Clubhouse workspace](https://app.shortcut.com/settings/users),
 open the Developer Tools in your browser, find the API request for
-`https://app.clubhouse.io/backend/api/private/members`,
+`https://app.shortcut.com/backend/api/private/members`,
 and examine the API response to find the `id` for each user.
 Note that Clubhouse makes a distinction between a `User` and a `Member`:
 you need to look up the UUID for the `Member` object.
@@ -179,7 +179,7 @@ Multiple users should be separated by commas.
 
 ## Iteration Support
 
-Clubhouse supports the concept of [iterations](https://help.clubhouse.io/hc/en-us/articles/360028953452-Iterations-Overview)
+Clubhouse supports the concept of [iterations](https://help.shortcut.com/hc/en-us/articles/360028953452-Iterations-Overview)
  -- time-boxed periods of development for stories. You can configure this Action
 to automatically assign the Clubhouse stories it creates to Clubhouse iterations,
 using GitHub labels and Clubhouse groups to identify the correct iteration to use.
@@ -187,7 +187,7 @@ using GitHub labels and Clubhouse groups to identify the correct iteration to us
 In order to use this feature, this Action makes a few assumptions about
 the way you use Clubhouse and GitHub:
 
-- We assume that each team has an associated [Clubhouse group](https://help.clubhouse.io/hc/en-us/articles/360039328751-Groups-Group-Management),
+- We assume that each team has an associated [Clubhouse group](https://help.shortcut.com/hc/en-us/articles/360039328751-Groups-Group-Management),
   and that Clubhouse iterations are associated with this group.
 - We assume that the correct iteration to use is the *most recent*
   in-progress iteration for the group, as determined by the "last updated" time.

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 test("getClubhouseUserId", async () => {
-  const chScope = nock("https://api.shortcut.com")
+  const chScope = nock("https://api.clubhoust.io")
     .get("/api/v3/members")
     .query(true)
     .reply(200, [
@@ -54,7 +54,7 @@ test("getClubhouseUserId user-map", async () => {
 });
 
 test("getClubhouseProjectByName", async () => {
-  const scope = nock("https://api.shortcut.com")
+  const scope = nock("https://api.clubhoust.io")
     .get("/api/v3/projects")
     .query(true)
     .reply(200, [{ id: "abc", name: "fake-project" }]);
@@ -67,7 +67,7 @@ test("getClubhouseProjectByName", async () => {
 });
 
 test("getClubhouseWorkflowState", async () => {
-  const scope = nock("https://api.shortcut.com")
+  const scope = nock("https://api.clubhoust.io")
     .get("/api/v3/teams/123")
     .query(true)
     .reply(200, {
@@ -130,7 +130,7 @@ describe("createClubhouseStory", () => {
     process.env["INPUT_STORY-DESCRIPTION-TEMPLATE"] =
       "{{{ payload.pull_request.body }}}";
 
-    scope = nock("https://api.shortcut.com")
+    scope = nock("https://api.clubhoust.io")
       .get("/api/v3/projects")
       .query(true)
       .reply(200, [{ id: "abc", name: "fake-project" }]);
@@ -340,7 +340,7 @@ describe("shouldProcessPullRequestForUser", () => {
 
 describe("getLatestMatchingClubhouseIteration", () => {
   test("happy path", async () => {
-    const scope = nock("https://api.shortcut.com")
+    const scope = nock("https://api.clubhoust.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -364,7 +364,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("no iterations", async () => {
-    const scope = nock("https://api.shortcut.com")
+    const scope = nock("https://api.clubhoust.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, []);
@@ -379,7 +379,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("matching unstarted iteration", async () => {
-    const scope = nock("https://api.shortcut.com")
+    const scope = nock("https://api.clubhoust.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -402,7 +402,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("multiple matches", async () => {
-    const scope = nock("https://api.shortcut.com")
+    const scope = nock("https://api.clubhoust.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -447,7 +447,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("excludes", async () => {
-    const scope = nock("https://api.shortcut.com")
+    const scope = nock("https://api.clubhoust.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 test("getClubhouseUserId", async () => {
-  const chScope = nock("https://api.clubhoust.io")
+  const chScope = nock("https://api.clubhouse.io")
     .get("/api/v3/members")
     .query(true)
     .reply(200, [
@@ -54,7 +54,7 @@ test("getClubhouseUserId user-map", async () => {
 });
 
 test("getClubhouseProjectByName", async () => {
-  const scope = nock("https://api.clubhoust.io")
+  const scope = nock("https://api.clubhouse.io")
     .get("/api/v3/projects")
     .query(true)
     .reply(200, [{ id: "abc", name: "fake-project" }]);
@@ -67,7 +67,7 @@ test("getClubhouseProjectByName", async () => {
 });
 
 test("getClubhouseWorkflowState", async () => {
-  const scope = nock("https://api.clubhoust.io")
+  const scope = nock("https://api.clubhouse.io")
     .get("/api/v3/teams/123")
     .query(true)
     .reply(200, {
@@ -130,7 +130,7 @@ describe("createClubhouseStory", () => {
     process.env["INPUT_STORY-DESCRIPTION-TEMPLATE"] =
       "{{{ payload.pull_request.body }}}";
 
-    scope = nock("https://api.clubhoust.io")
+    scope = nock("https://api.clubhouse.io")
       .get("/api/v3/projects")
       .query(true)
       .reply(200, [{ id: "abc", name: "fake-project" }]);
@@ -340,7 +340,7 @@ describe("shouldProcessPullRequestForUser", () => {
 
 describe("getLatestMatchingClubhouseIteration", () => {
   test("happy path", async () => {
-    const scope = nock("https://api.clubhoust.io")
+    const scope = nock("https://api.clubhouse.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -364,7 +364,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("no iterations", async () => {
-    const scope = nock("https://api.clubhoust.io")
+    const scope = nock("https://api.clubhouse.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, []);
@@ -379,7 +379,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("matching unstarted iteration", async () => {
-    const scope = nock("https://api.clubhoust.io")
+    const scope = nock("https://api.clubhouse.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -402,7 +402,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("multiple matches", async () => {
-    const scope = nock("https://api.clubhoust.io")
+    const scope = nock("https://api.clubhouse.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -447,7 +447,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("excludes", async () => {
-    const scope = nock("https://api.clubhoust.io")
+    const scope = nock("https://api.clubhouse.io")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 test("getClubhouseUserId", async () => {
-  const chScope = nock("https://api.clubhouse.io")
+  const chScope = nock("https://api.shortcut.com")
     .get("/api/v3/members")
     .query(true)
     .reply(200, [
@@ -54,7 +54,7 @@ test("getClubhouseUserId user-map", async () => {
 });
 
 test("getClubhouseProjectByName", async () => {
-  const scope = nock("https://api.clubhouse.io")
+  const scope = nock("https://api.shortcut.com")
     .get("/api/v3/projects")
     .query(true)
     .reply(200, [{ id: "abc", name: "fake-project" }]);
@@ -67,7 +67,7 @@ test("getClubhouseProjectByName", async () => {
 });
 
 test("getClubhouseWorkflowState", async () => {
-  const scope = nock("https://api.clubhouse.io")
+  const scope = nock("https://api.shortcut.com")
     .get("/api/v3/teams/123")
     .query(true)
     .reply(200, {
@@ -130,7 +130,7 @@ describe("createClubhouseStory", () => {
     process.env["INPUT_STORY-DESCRIPTION-TEMPLATE"] =
       "{{{ payload.pull_request.body }}}";
 
-    scope = nock("https://api.clubhouse.io")
+    scope = nock("https://api.shortcut.com")
       .get("/api/v3/projects")
       .query(true)
       .reply(200, [{ id: "abc", name: "fake-project" }]);
@@ -248,7 +248,7 @@ test("getClubhouseURLFromPullRequest", async () => {
 test("getClubhouseURLFromPullRequest desc", async () => {
   const payload = {
     pull_request: {
-      body: "Clubhouse story: https://app.clubhouse.io/org/story/12345",
+      body: "Clubhouse story: https://app.shortcut.com/org/story/12345",
       number: 123,
     },
     repository: {
@@ -260,7 +260,7 @@ test("getClubhouseURLFromPullRequest desc", async () => {
   };
 
   const url = await util.getClubhouseURLFromPullRequest(payload as any);
-  expect(url).toEqual("https://app.clubhouse.io/org/story/12345");
+  expect(url).toEqual("https://app.shortcut.com/org/story/12345");
 });
 
 test("getClubhouseURLFromPullRequest comment", async () => {
@@ -281,11 +281,11 @@ test("getClubhouseURLFromPullRequest comment", async () => {
     .get("/repos/octocat/example/issues/123/comments")
     .reply(200, [
       { body: "no url here, either!" },
-      { body: "Clubhouse story: https://app.clubhouse.io/org/story/12345" },
+      { body: "Clubhouse story: https://app.shortcut.com/org/story/12345" },
     ]);
 
   const url = await util.getClubhouseURLFromPullRequest(payload as any);
-  expect(url).toEqual("https://app.clubhouse.io/org/story/12345");
+  expect(url).toEqual("https://app.shortcut.com/org/story/12345");
 
   scope.done();
 });
@@ -340,7 +340,7 @@ describe("shouldProcessPullRequestForUser", () => {
 
 describe("getLatestMatchingClubhouseIteration", () => {
   test("happy path", async () => {
-    const scope = nock("https://api.clubhouse.io")
+    const scope = nock("https://api.shortcut.com")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -364,7 +364,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("no iterations", async () => {
-    const scope = nock("https://api.clubhouse.io")
+    const scope = nock("https://api.shortcut.com")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, []);
@@ -379,7 +379,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("matching unstarted iteration", async () => {
-    const scope = nock("https://api.clubhouse.io")
+    const scope = nock("https://api.shortcut.com")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -402,7 +402,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("multiple matches", async () => {
-    const scope = nock("https://api.clubhouse.io")
+    const scope = nock("https://api.shortcut.com")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [
@@ -447,7 +447,7 @@ describe("getLatestMatchingClubhouseIteration", () => {
   });
 
   test("excludes", async () => {
-    const scope = nock("https://api.clubhouse.io")
+    const scope = nock("https://api.shortcut.com")
       .get("/api/v3/iterations")
       .query(true)
       .reply(200, [

--- a/dist/index.js
+++ b/dist/index.js
@@ -368,7 +368,7 @@ exports.delay = exports.getClubhouseIterationInfo = exports.getLatestMatchingClu
 const core = __importStar(__nccwpck_require__(186));
 const github = __importStar(__nccwpck_require__(438));
 const mustache_1 = __importDefault(__nccwpck_require__(272));
-exports.CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
+exports.CLUBHOUSE_STORY_URL_REGEXP = /https:\/\/app.shortcut.com\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
 exports.CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?ch(\d+)(?:[-/].+)?$/;
 /**
  * Convert a Map to a sorted string representation. Useful for debugging.
@@ -448,10 +448,10 @@ function getClubhouseUserId(githubUsername, http) {
         });
         let emailToClubhouseId;
         try {
-            const membersResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`);
+            const membersResponse = yield http.getJson(`https://api.shortcut.com/api/v3/members?token=${CLUBHOUSE_TOKEN}`);
             const members = membersResponse.result;
             if (!members) {
-                core.setFailed(`HTTP ${membersResponse.statusCode} https://api.clubhouse.io/api/v3/members`);
+                core.setFailed(`HTTP ${membersResponse.statusCode} https://api.shortcut.com/api/v3/members`);
                 return;
             }
             emailToClubhouseId = members.reduce((e2id, member) => {
@@ -465,7 +465,7 @@ function getClubhouseUserId(githubUsername, http) {
             core.debug(`email to Clubhouse ID: ${stringFromMap(emailToClubhouseId)}`);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/members\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/members\n${err.message}`);
             return;
         }
         const GITHUB_TOKEN = core.getInput("github-token", {
@@ -491,15 +491,15 @@ function getClubhouseStoryById(id, http) {
             required: true,
         });
         try {
-            const storyResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`);
+            const storyResponse = yield http.getJson(`https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`);
             }
             return story;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`);
             return null;
         }
     });
@@ -511,11 +511,11 @@ function getClubhouseProject(id, http) {
             required: true,
         });
         try {
-            const projectResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`);
+            const projectResponse = yield http.getJson(`https://api.shortcut.com/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`);
             return projectResponse.result;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects/${id}\n${err.message}`);
             return null;
         }
     });
@@ -527,16 +527,16 @@ function getClubhouseProjectByName(projectName, http) {
             required: true,
         });
         try {
-            const projectsResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`);
+            const projectsResponse = yield http.getJson(`https://api.shortcut.com/api/v3/projects?token=${CLUBHOUSE_TOKEN}`);
             const projects = projectsResponse.result;
             if (!projects) {
-                core.setFailed(`HTTP ${projectsResponse.statusCode} https://api.clubhouse.io/api/v3/projects`);
+                core.setFailed(`HTTP ${projectsResponse.statusCode} https://api.shortcut.com/api/v3/projects`);
                 return;
             }
             return projects.find((project) => project.name === projectName);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects\n${err.message}`);
             return;
         }
     });
@@ -549,16 +549,16 @@ function getClubhouseWorkflowState(stateName, http, project) {
         });
         const teamId = project.team_id;
         try {
-            const teamResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`);
+            const teamResponse = yield http.getJson(`https://api.shortcut.com/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`);
             const team = teamResponse.result;
             if (!team) {
-                core.setFailed(`HTTP ${teamResponse.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}`);
+                core.setFailed(`HTTP ${teamResponse.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}`);
                 return null;
             }
             return (team.workflow.states.find((state) => state.name === stateName) || null);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}\n${err.message}`);
             return null;
         }
     });
@@ -596,16 +596,16 @@ function createClubhouseStory(payload, http) {
             }
         }
         try {
-            const storyResponse = yield http.postJson(`https://api.clubhouse.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`, body);
+            const storyResponse = yield http.postJson(`https://api.shortcut.com/api/v3/stories?token=${CLUBHOUSE_TOKEN}`, body);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}`);
                 return null;
             }
             return storyResponse.result;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}\n${err.message}`);
             return null;
         }
     });
@@ -700,15 +700,15 @@ function updateClubhouseStoryById(id, http, body) {
             required: true,
         });
         try {
-            const storyResponse = yield http.putJson(`https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`, body);
+            const storyResponse = yield http.putJson(`https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`, body);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`);
             }
             return story;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`);
             return null;
         }
     });
@@ -720,10 +720,10 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
             required: true,
         });
         try {
-            const iterationsResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`);
+            const iterationsResponse = yield http.getJson(`https://api.shortcut.com/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`);
             const iterations = iterationsResponse.result;
             if (!iterations) {
-                core.setFailed(`HTTP ${iterationsResponse.statusCode} https://api.clubhouse.io/api/v3/iterations`);
+                core.setFailed(`HTTP ${iterationsResponse.statusCode} https://api.shortcut.com/api/v3/iterations`);
                 return;
             }
             const iterationsForGroup = iterations.filter((iteration) => {
@@ -747,7 +747,7 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
             return sortedIterations[0];
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/iterations\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/iterations\n${err.message}`);
             return;
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -448,10 +448,10 @@ function getClubhouseUserId(githubUsername, http) {
         });
         let emailToClubhouseId;
         try {
-            const membersResponse = yield http.getJson(`https://api.shortcut.com/api/v3/members?token=${CLUBHOUSE_TOKEN}`);
+            const membersResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`);
             const members = membersResponse.result;
             if (!members) {
-                core.setFailed(`HTTP ${membersResponse.statusCode} https://api.shortcut.com/api/v3/members`);
+                core.setFailed(`HTTP ${membersResponse.statusCode} https://api.clubhoust.io/api/v3/members`);
                 return;
             }
             emailToClubhouseId = members.reduce((e2id, member) => {
@@ -465,7 +465,7 @@ function getClubhouseUserId(githubUsername, http) {
             core.debug(`email to Clubhouse ID: ${stringFromMap(emailToClubhouseId)}`);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/members\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/members\n${err.message}`);
             return;
         }
         const GITHUB_TOKEN = core.getInput("github-token", {
@@ -491,15 +491,15 @@ function getClubhouseStoryById(id, http) {
             required: true,
         });
         try {
-            const storyResponse = yield http.getJson(`https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`);
+            const storyResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`);
             }
             return story;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`);
             return null;
         }
     });
@@ -511,11 +511,11 @@ function getClubhouseProject(id, http) {
             required: true,
         });
         try {
-            const projectResponse = yield http.getJson(`https://api.shortcut.com/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`);
+            const projectResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`);
             return projectResponse.result;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects/${id}\n${err.message}`);
             return null;
         }
     });
@@ -527,16 +527,16 @@ function getClubhouseProjectByName(projectName, http) {
             required: true,
         });
         try {
-            const projectsResponse = yield http.getJson(`https://api.shortcut.com/api/v3/projects?token=${CLUBHOUSE_TOKEN}`);
+            const projectsResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`);
             const projects = projectsResponse.result;
             if (!projects) {
-                core.setFailed(`HTTP ${projectsResponse.statusCode} https://api.shortcut.com/api/v3/projects`);
+                core.setFailed(`HTTP ${projectsResponse.statusCode} https://api.clubhoust.io/api/v3/projects`);
                 return;
             }
             return projects.find((project) => project.name === projectName);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects\n${err.message}`);
             return;
         }
     });
@@ -549,16 +549,16 @@ function getClubhouseWorkflowState(stateName, http, project) {
         });
         const teamId = project.team_id;
         try {
-            const teamResponse = yield http.getJson(`https://api.shortcut.com/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`);
+            const teamResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`);
             const team = teamResponse.result;
             if (!team) {
-                core.setFailed(`HTTP ${teamResponse.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}`);
+                core.setFailed(`HTTP ${teamResponse.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}`);
                 return null;
             }
             return (team.workflow.states.find((state) => state.name === stateName) || null);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}\n${err.message}`);
             return null;
         }
     });
@@ -596,16 +596,16 @@ function createClubhouseStory(payload, http) {
             }
         }
         try {
-            const storyResponse = yield http.postJson(`https://api.shortcut.com/api/v3/stories?token=${CLUBHOUSE_TOKEN}`, body);
+            const storyResponse = yield http.postJson(`https://api.clubhoust.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`, body);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}`);
                 return null;
             }
             return storyResponse.result;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}\n${err.message}`);
             return null;
         }
     });
@@ -700,15 +700,15 @@ function updateClubhouseStoryById(id, http, body) {
             required: true,
         });
         try {
-            const storyResponse = yield http.putJson(`https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`, body);
+            const storyResponse = yield http.putJson(`https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`, body);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`);
             }
             return story;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`);
             return null;
         }
     });
@@ -720,10 +720,10 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
             required: true,
         });
         try {
-            const iterationsResponse = yield http.getJson(`https://api.shortcut.com/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`);
+            const iterationsResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`);
             const iterations = iterationsResponse.result;
             if (!iterations) {
-                core.setFailed(`HTTP ${iterationsResponse.statusCode} https://api.shortcut.com/api/v3/iterations`);
+                core.setFailed(`HTTP ${iterationsResponse.statusCode} https://api.clubhoust.io/api/v3/iterations`);
                 return;
             }
             const iterationsForGroup = iterations.filter((iteration) => {
@@ -747,7 +747,7 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
             return sortedIterations[0];
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.shortcut.com/api/v3/iterations\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/iterations\n${err.message}`);
             return;
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -448,10 +448,10 @@ function getClubhouseUserId(githubUsername, http) {
         });
         let emailToClubhouseId;
         try {
-            const membersResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`);
+            const membersResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`);
             const members = membersResponse.result;
             if (!members) {
-                core.setFailed(`HTTP ${membersResponse.statusCode} https://api.clubhoust.io/api/v3/members`);
+                core.setFailed(`HTTP ${membersResponse.statusCode} https://api.clubhouse.io/api/v3/members`);
                 return;
             }
             emailToClubhouseId = members.reduce((e2id, member) => {
@@ -465,7 +465,7 @@ function getClubhouseUserId(githubUsername, http) {
             core.debug(`email to Clubhouse ID: ${stringFromMap(emailToClubhouseId)}`);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/members\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/members\n${err.message}`);
             return;
         }
         const GITHUB_TOKEN = core.getInput("github-token", {
@@ -491,15 +491,15 @@ function getClubhouseStoryById(id, http) {
             required: true,
         });
         try {
-            const storyResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`);
+            const storyResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`);
             }
             return story;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`);
             return null;
         }
     });
@@ -511,11 +511,11 @@ function getClubhouseProject(id, http) {
             required: true,
         });
         try {
-            const projectResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`);
+            const projectResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`);
             return projectResponse.result;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects/${id}\n${err.message}`);
             return null;
         }
     });
@@ -527,16 +527,16 @@ function getClubhouseProjectByName(projectName, http) {
             required: true,
         });
         try {
-            const projectsResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`);
+            const projectsResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`);
             const projects = projectsResponse.result;
             if (!projects) {
-                core.setFailed(`HTTP ${projectsResponse.statusCode} https://api.clubhoust.io/api/v3/projects`);
+                core.setFailed(`HTTP ${projectsResponse.statusCode} https://api.clubhouse.io/api/v3/projects`);
                 return;
             }
             return projects.find((project) => project.name === projectName);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects\n${err.message}`);
             return;
         }
     });
@@ -549,16 +549,16 @@ function getClubhouseWorkflowState(stateName, http, project) {
         });
         const teamId = project.team_id;
         try {
-            const teamResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`);
+            const teamResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`);
             const team = teamResponse.result;
             if (!team) {
-                core.setFailed(`HTTP ${teamResponse.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}`);
+                core.setFailed(`HTTP ${teamResponse.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}`);
                 return null;
             }
             return (team.workflow.states.find((state) => state.name === stateName) || null);
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}\n${err.message}`);
             return null;
         }
     });
@@ -596,16 +596,16 @@ function createClubhouseStory(payload, http) {
             }
         }
         try {
-            const storyResponse = yield http.postJson(`https://api.clubhoust.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`, body);
+            const storyResponse = yield http.postJson(`https://api.clubhouse.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`, body);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}`);
                 return null;
             }
             return storyResponse.result;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}\n${err.message}`);
             return null;
         }
     });
@@ -700,15 +700,15 @@ function updateClubhouseStoryById(id, http, body) {
             required: true,
         });
         try {
-            const storyResponse = yield http.putJson(`https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`, body);
+            const storyResponse = yield http.putJson(`https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`, body);
             const story = storyResponse.result;
             if (!story) {
-                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`);
+                core.setFailed(`HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`);
             }
             return story;
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`);
             return null;
         }
     });
@@ -720,10 +720,10 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
             required: true,
         });
         try {
-            const iterationsResponse = yield http.getJson(`https://api.clubhoust.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`);
+            const iterationsResponse = yield http.getJson(`https://api.clubhouse.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`);
             const iterations = iterationsResponse.result;
             if (!iterations) {
-                core.setFailed(`HTTP ${iterationsResponse.statusCode} https://api.clubhoust.io/api/v3/iterations`);
+                core.setFailed(`HTTP ${iterationsResponse.statusCode} https://api.clubhouse.io/api/v3/iterations`);
                 return;
             }
             const iterationsForGroup = iterations.filter((iteration) => {
@@ -747,7 +747,7 @@ function getLatestMatchingClubhouseIteration(iterationInfo, http) {
             return sortedIterations[0];
         }
         catch (err) {
-            core.setFailed(`HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/iterations\n${err.message}`);
+            core.setFailed(`HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/iterations\n${err.message}`);
             return;
         }
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -125,12 +125,12 @@ export async function getClubhouseUserId(
 
   try {
     const membersResponse = await http.getJson<ClubhouseMember[]>(
-      `https://api.clubhoust.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhouse.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`
     );
     const members = membersResponse.result;
     if (!members) {
       core.setFailed(
-        `HTTP ${membersResponse.statusCode} https://api.clubhoust.io/api/v3/members`
+        `HTTP ${membersResponse.statusCode} https://api.clubhouse.io/api/v3/members`
       );
       return;
     }
@@ -145,7 +145,7 @@ export async function getClubhouseUserId(
     core.debug(`email to Clubhouse ID: ${stringFromMap(emailToClubhouseId)}`);
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/members\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/members\n${err.message}`
     );
     return;
   }
@@ -177,18 +177,18 @@ export async function getClubhouseStoryById(
   });
   try {
     const storyResponse = await http.getJson<ClubhouseStory>(
-      `https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`
     );
     const story = storyResponse.result;
     if (!story) {
       core.setFailed(
-        `HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`
+        `HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`
       );
     }
     return story;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`
     );
     return null;
   }
@@ -203,12 +203,12 @@ export async function getClubhouseProject(
   });
   try {
     const projectResponse = await http.getJson<ClubhouseProject>(
-      `https://api.clubhoust.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhouse.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`
     );
     return projectResponse.result;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects/${id}\n${err.message}`
     );
     return null;
   }
@@ -223,19 +223,19 @@ export async function getClubhouseProjectByName(
   });
   try {
     const projectsResponse = await http.getJson<ClubhouseProject[]>(
-      `https://api.clubhoust.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhouse.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`
     );
     const projects = projectsResponse.result;
     if (!projects) {
       core.setFailed(
-        `HTTP ${projectsResponse.statusCode} https://api.clubhoust.io/api/v3/projects`
+        `HTTP ${projectsResponse.statusCode} https://api.clubhouse.io/api/v3/projects`
       );
       return;
     }
     return projects.find((project) => project.name === projectName);
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects\n${err.message}`
     );
     return;
   }
@@ -254,13 +254,13 @@ export async function getClubhouseWorkflowState(
 
   try {
     const teamResponse = await http.getJson<ClubhouseTeam>(
-      `https://api.clubhoust.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhouse.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`
     );
 
     const team = teamResponse.result;
     if (!team) {
       core.setFailed(
-        `HTTP ${teamResponse.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}`
+        `HTTP ${teamResponse.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}`
       );
       return null;
     }
@@ -270,7 +270,7 @@ export async function getClubhouseWorkflowState(
     );
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}\n${err.message}`
     );
     return null;
   }
@@ -319,7 +319,7 @@ export async function createClubhouseStory(
 
   try {
     const storyResponse = await http.postJson<ClubhouseStory>(
-      `https://api.clubhoust.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`,
+      `https://api.clubhouse.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`,
       body
     );
     const story = storyResponse.result;
@@ -327,7 +327,7 @@ export async function createClubhouseStory(
       core.setFailed(
         `HTTP ${
           storyResponse.statusCode
-        } https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}`
+        } https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}`
       );
       return null;
     }
@@ -336,7 +336,7 @@ export async function createClubhouseStory(
     core.setFailed(
       `HTTP ${
         err.statusCode
-      } https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}\n${
+      } https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}\n${
         err.message
       }`
     );
@@ -454,19 +454,19 @@ export async function updateClubhouseStoryById(
   });
   try {
     const storyResponse = await http.putJson<ClubhouseStory>(
-      `https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`,
+      `https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`,
       body
     );
     const story = storyResponse.result;
     if (!story) {
       core.setFailed(
-        `HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`
+        `HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`
       );
     }
     return story;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`
     );
     return null;
   }
@@ -481,12 +481,12 @@ export async function getLatestMatchingClubhouseIteration(
   });
   try {
     const iterationsResponse = await http.getJson<ClubhouseIterationSlim[]>(
-      `https://api.clubhoust.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhouse.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`
     );
     const iterations = iterationsResponse.result;
     if (!iterations) {
       core.setFailed(
-        `HTTP ${iterationsResponse.statusCode} https://api.clubhoust.io/api/v3/iterations`
+        `HTTP ${iterationsResponse.statusCode} https://api.clubhouse.io/api/v3/iterations`
       );
       return;
     }
@@ -515,7 +515,7 @@ export async function getLatestMatchingClubhouseIteration(
     return sortedIterations[0];
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/iterations\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/iterations\n${err.message}`
     );
     return;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ import {
 } from "./types";
 
 export const CLUBHOUSE_STORY_URL_REGEXP =
-  /https:\/\/app.clubhouse.io\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
+  /https:\/\/app.shortcut.com\/\w+\/story\/(\d+)(\/[A-Za-z0-9-]*)?/;
 export const CLUBHOUSE_BRANCH_NAME_REGEXP = /^(?:.+[-/])?ch(\d+)(?:[-/].+)?$/;
 
 interface Stringable {
@@ -125,12 +125,12 @@ export async function getClubhouseUserId(
 
   try {
     const membersResponse = await http.getJson<ClubhouseMember[]>(
-      `https://api.clubhouse.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`
+      `https://api.shortcut.com/api/v3/members?token=${CLUBHOUSE_TOKEN}`
     );
     const members = membersResponse.result;
     if (!members) {
       core.setFailed(
-        `HTTP ${membersResponse.statusCode} https://api.clubhouse.io/api/v3/members`
+        `HTTP ${membersResponse.statusCode} https://api.shortcut.com/api/v3/members`
       );
       return;
     }
@@ -145,7 +145,7 @@ export async function getClubhouseUserId(
     core.debug(`email to Clubhouse ID: ${stringFromMap(emailToClubhouseId)}`);
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/members\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/members\n${err.message}`
     );
     return;
   }
@@ -177,18 +177,18 @@ export async function getClubhouseStoryById(
   });
   try {
     const storyResponse = await http.getJson<ClubhouseStory>(
-      `https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`
     );
     const story = storyResponse.result;
     if (!story) {
       core.setFailed(
-        `HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`
+        `HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`
       );
     }
     return story;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`
     );
     return null;
   }
@@ -203,12 +203,12 @@ export async function getClubhouseProject(
   });
   try {
     const projectResponse = await http.getJson<ClubhouseProject>(
-      `https://api.clubhouse.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.shortcut.com/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`
     );
     return projectResponse.result;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects/${id}\n${err.message}`
     );
     return null;
   }
@@ -223,19 +223,19 @@ export async function getClubhouseProjectByName(
   });
   try {
     const projectsResponse = await http.getJson<ClubhouseProject[]>(
-      `https://api.clubhouse.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`
+      `https://api.shortcut.com/api/v3/projects?token=${CLUBHOUSE_TOKEN}`
     );
     const projects = projectsResponse.result;
     if (!projects) {
       core.setFailed(
-        `HTTP ${projectsResponse.statusCode} https://api.clubhouse.io/api/v3/projects`
+        `HTTP ${projectsResponse.statusCode} https://api.shortcut.com/api/v3/projects`
       );
       return;
     }
     return projects.find((project) => project.name === projectName);
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/projects\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects\n${err.message}`
     );
     return;
   }
@@ -254,13 +254,13 @@ export async function getClubhouseWorkflowState(
 
   try {
     const teamResponse = await http.getJson<ClubhouseTeam>(
-      `https://api.clubhouse.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.shortcut.com/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`
     );
 
     const team = teamResponse.result;
     if (!team) {
       core.setFailed(
-        `HTTP ${teamResponse.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}`
+        `HTTP ${teamResponse.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}`
       );
       return null;
     }
@@ -270,7 +270,7 @@ export async function getClubhouseWorkflowState(
     );
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/teams/${teamId}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}\n${err.message}`
     );
     return null;
   }
@@ -319,7 +319,7 @@ export async function createClubhouseStory(
 
   try {
     const storyResponse = await http.postJson<ClubhouseStory>(
-      `https://api.clubhouse.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`,
+      `https://api.shortcut.com/api/v3/stories?token=${CLUBHOUSE_TOKEN}`,
       body
     );
     const story = storyResponse.result;
@@ -327,7 +327,7 @@ export async function createClubhouseStory(
       core.setFailed(
         `HTTP ${
           storyResponse.statusCode
-        } https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}`
+        } https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}`
       );
       return null;
     }
@@ -336,7 +336,7 @@ export async function createClubhouseStory(
     core.setFailed(
       `HTTP ${
         err.statusCode
-      } https://api.clubhouse.io/api/v3/stories\n${JSON.stringify(body)}\n${
+      } https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}\n${
         err.message
       }`
     );
@@ -454,19 +454,19 @@ export async function updateClubhouseStoryById(
   });
   try {
     const storyResponse = await http.putJson<ClubhouseStory>(
-      `https://api.clubhouse.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`,
+      `https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`,
       body
     );
     const story = storyResponse.result;
     if (!story) {
       core.setFailed(
-        `HTTP ${storyResponse.statusCode} https://api.clubhouse.io/api/v3/stories/${id}`
+        `HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`
       );
     }
     return story;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/stories/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`
     );
     return null;
   }
@@ -481,12 +481,12 @@ export async function getLatestMatchingClubhouseIteration(
   });
   try {
     const iterationsResponse = await http.getJson<ClubhouseIterationSlim[]>(
-      `https://api.clubhouse.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`
+      `https://api.shortcut.com/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`
     );
     const iterations = iterationsResponse.result;
     if (!iterations) {
       core.setFailed(
-        `HTTP ${iterationsResponse.statusCode} https://api.clubhouse.io/api/v3/iterations`
+        `HTTP ${iterationsResponse.statusCode} https://api.shortcut.com/api/v3/iterations`
       );
       return;
     }
@@ -515,7 +515,7 @@ export async function getLatestMatchingClubhouseIteration(
     return sortedIterations[0];
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.clubhouse.io/api/v3/iterations\n${err.message}`
+      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/iterations\n${err.message}`
     );
     return;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -125,12 +125,12 @@ export async function getClubhouseUserId(
 
   try {
     const membersResponse = await http.getJson<ClubhouseMember[]>(
-      `https://api.shortcut.com/api/v3/members?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhoust.io/api/v3/members?token=${CLUBHOUSE_TOKEN}`
     );
     const members = membersResponse.result;
     if (!members) {
       core.setFailed(
-        `HTTP ${membersResponse.statusCode} https://api.shortcut.com/api/v3/members`
+        `HTTP ${membersResponse.statusCode} https://api.clubhoust.io/api/v3/members`
       );
       return;
     }
@@ -145,7 +145,7 @@ export async function getClubhouseUserId(
     core.debug(`email to Clubhouse ID: ${stringFromMap(emailToClubhouseId)}`);
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/members\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/members\n${err.message}`
     );
     return;
   }
@@ -177,18 +177,18 @@ export async function getClubhouseStoryById(
   });
   try {
     const storyResponse = await http.getJson<ClubhouseStory>(
-      `https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`
     );
     const story = storyResponse.result;
     if (!story) {
       core.setFailed(
-        `HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`
+        `HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`
       );
     }
     return story;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`
     );
     return null;
   }
@@ -203,12 +203,12 @@ export async function getClubhouseProject(
   });
   try {
     const projectResponse = await http.getJson<ClubhouseProject>(
-      `https://api.shortcut.com/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhoust.io/api/v3/projects/${id}?token=${CLUBHOUSE_TOKEN}`
     );
     return projectResponse.result;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects/${id}\n${err.message}`
     );
     return null;
   }
@@ -223,19 +223,19 @@ export async function getClubhouseProjectByName(
   });
   try {
     const projectsResponse = await http.getJson<ClubhouseProject[]>(
-      `https://api.shortcut.com/api/v3/projects?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhoust.io/api/v3/projects?token=${CLUBHOUSE_TOKEN}`
     );
     const projects = projectsResponse.result;
     if (!projects) {
       core.setFailed(
-        `HTTP ${projectsResponse.statusCode} https://api.shortcut.com/api/v3/projects`
+        `HTTP ${projectsResponse.statusCode} https://api.clubhoust.io/api/v3/projects`
       );
       return;
     }
     return projects.find((project) => project.name === projectName);
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/projects\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/projects\n${err.message}`
     );
     return;
   }
@@ -254,13 +254,13 @@ export async function getClubhouseWorkflowState(
 
   try {
     const teamResponse = await http.getJson<ClubhouseTeam>(
-      `https://api.shortcut.com/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhoust.io/api/v3/teams/${teamId}?token=${CLUBHOUSE_TOKEN}`
     );
 
     const team = teamResponse.result;
     if (!team) {
       core.setFailed(
-        `HTTP ${teamResponse.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}`
+        `HTTP ${teamResponse.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}`
       );
       return null;
     }
@@ -270,7 +270,7 @@ export async function getClubhouseWorkflowState(
     );
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/teams/${teamId}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/teams/${teamId}\n${err.message}`
     );
     return null;
   }
@@ -319,7 +319,7 @@ export async function createClubhouseStory(
 
   try {
     const storyResponse = await http.postJson<ClubhouseStory>(
-      `https://api.shortcut.com/api/v3/stories?token=${CLUBHOUSE_TOKEN}`,
+      `https://api.clubhoust.io/api/v3/stories?token=${CLUBHOUSE_TOKEN}`,
       body
     );
     const story = storyResponse.result;
@@ -327,7 +327,7 @@ export async function createClubhouseStory(
       core.setFailed(
         `HTTP ${
           storyResponse.statusCode
-        } https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}`
+        } https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}`
       );
       return null;
     }
@@ -336,7 +336,7 @@ export async function createClubhouseStory(
     core.setFailed(
       `HTTP ${
         err.statusCode
-      } https://api.shortcut.com/api/v3/stories\n${JSON.stringify(body)}\n${
+      } https://api.clubhoust.io/api/v3/stories\n${JSON.stringify(body)}\n${
         err.message
       }`
     );
@@ -454,19 +454,19 @@ export async function updateClubhouseStoryById(
   });
   try {
     const storyResponse = await http.putJson<ClubhouseStory>(
-      `https://api.shortcut.com/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`,
+      `https://api.clubhoust.io/api/v3/stories/${id}?token=${CLUBHOUSE_TOKEN}`,
       body
     );
     const story = storyResponse.result;
     if (!story) {
       core.setFailed(
-        `HTTP ${storyResponse.statusCode} https://api.shortcut.com/api/v3/stories/${id}`
+        `HTTP ${storyResponse.statusCode} https://api.clubhoust.io/api/v3/stories/${id}`
       );
     }
     return story;
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/stories/${id}\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/stories/${id}\n${err.message}`
     );
     return null;
   }
@@ -481,12 +481,12 @@ export async function getLatestMatchingClubhouseIteration(
   });
   try {
     const iterationsResponse = await http.getJson<ClubhouseIterationSlim[]>(
-      `https://api.shortcut.com/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`
+      `https://api.clubhoust.io/api/v3/iterations?token=${CLUBHOUSE_TOKEN}`
     );
     const iterations = iterationsResponse.result;
     if (!iterations) {
       core.setFailed(
-        `HTTP ${iterationsResponse.statusCode} https://api.shortcut.com/api/v3/iterations`
+        `HTTP ${iterationsResponse.statusCode} https://api.clubhoust.io/api/v3/iterations`
       );
       return;
     }
@@ -515,7 +515,7 @@ export async function getLatestMatchingClubhouseIteration(
     return sortedIterations[0];
   } catch (err) {
     core.setFailed(
-      `HTTP ${err.statusCode} https://api.shortcut.com/api/v3/iterations\n${err.message}`
+      `HTTP ${err.statusCode} https://api.clubhoust.io/api/v3/iterations\n${err.message}`
     );
     return;
   }


### PR DESCRIPTION
Clubhouse/shortcut is now returning shortcut.com URLS, which breaks this package because the CLUBHOUSE_STORY_URL_REGEXP no longer matches.

There's an even bigger find/replace job necessary to truly bring this up to the new branding, but for now, this makes this work again.

**Of particular note**: `api.shortcut.com` does _not_ resolve, so we still hit `api.clubhouse.io` (for now)